### PR TITLE
Added artifact version per generated artifact, and extended tests acc…

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,12 +74,12 @@ const yargsConfig = yargs
   .describe('vocabTermsFrom', 'Generates Vocab Terms from only the specified ontology file.')
 
   .alias('av', 'artifactVersion')
-  .describe('artifactVersion', 'The version of the Node module that will be generated.')
+  .describe('artifactVersion', 'The version of the artifact(s) to be generated.')
   .default('artifactVersion', '0.0.1')
 
   .alias('at', 'artifactType')
   .describe('artifactType', 'The artifact type that will be generated.')
-  .choices('artifactType', ['nodejs']) // Add to this when other languages are supported.
+  .choices('artifactType', ['nodejs', 'java']) // Add to this when other languages are supported.
   .default('artifactType', 'nodejs')
 
   .alias('mnp', 'moduleNamePrefix')

--- a/src/Resources.js
+++ b/src/Resources.js
@@ -29,14 +29,14 @@ module.exports = class Resources {
   /**
    *
    * @param datasetFiles
-   * @param vocabTermsFromFile
+   * @param vocabTermsFromResource
    * @param fileResourcesRelativeTo If we load resources locally from the file system, make them relative to this path
    * (e.g. for reading resources from a vocab list file that can be anywhere, all local resources referenced in it
    * should be relative to wherever that list file itself is!).
    */
-  constructor(datasetFiles, vocabTermsFromFile, fileResourcesRelativeTo) {
+  constructor(datasetFiles, vocabTermsFromResource, fileResourcesRelativeTo) {
     this.datasetFiles = datasetFiles;
-    this.subjectsOnlyFile = vocabTermsFromFile;
+    this.vocabTermsFromResource = vocabTermsFromResource;
     this.fileResourcesRelativeTo = fileResourcesRelativeTo;
   }
 
@@ -46,13 +46,17 @@ module.exports = class Resources {
 
     const datasets = await Promise.all(datasetsPromises);
 
-    let subjectsOnlyDataset;
-    if (this.subjectsOnlyFile) {
-      subjectsOnlyDataset = await this.readResource(this.subjectsOnlyFile);
-      datasets.push(subjectsOnlyDataset); // Adds the extension to the full data set.
+    let vocabTermsFromDataset;
+    if (this.vocabTermsFromResource) {
+      vocabTermsFromDataset = await this.readResource(this.vocabTermsFromResource);
+
+      // We also add the terms from this resource to our collection of input datasets, since we expect it to contain
+      // possible extensions (e.g. translations of labels of comments into new languages, or possibly completely new
+      // terms).
+      datasets.push(vocabTermsFromDataset);
     }
 
-    processInputsCallback(datasets, subjectsOnlyDataset);
+    processInputsCallback(datasets, vocabTermsFromDataset);
   }
 
   readResource(datasetFile) {

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -7,8 +7,6 @@ const CommandLine = require('./CommandLine');
 
 // These values are not expected to be specified in vocab list files - they
 // are expected to be provided as runtime arguments.
-const VERSION_ARTIFACT_GENERATED = '0.1.0-SNAPSHOT';
-
 const VERSION_LIT_VOCAB_TERM = '^0.1.0'; // TODO: SHOULD BE IRRELEVANT NOW (FOR VOCAB LIST FILES, AS THEY PROVIDE PER PROGRAMMING LANGUAGE)...!?
 const NPM_REGISTRY = 'http://localhost:4873';
 const RUN_NPM_INSTALL = false;
@@ -22,7 +20,6 @@ const GenerationConfigLitCommon = {
   outputDirectory: '../../../../Solid/MonoRepo/testLit/packages/Vocab/LIT/Common',
   moduleNamePrefix: '@lit/generated-vocab-', // TODO: SHOULD BE IRRELEVANT NOW (FOR VOCAB LIST FILES)...!?
   artifactName: 'common',
-  artifactVersion: VERSION_ARTIFACT_GENERATED,
   litVocabTermVersion: VERSION_LIT_VOCAB_TERM, // TODO: SHOULD BE IRRELEVANT NOW (FOR VOCAB LIST FILES)...!?
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -37,7 +34,6 @@ const GenerationConfigSolidCommon = {
   outputDirectory: '../../../../Solid/MonoRepo/testLit/packages/Vocab/SolidCommon',
   moduleNamePrefix: '@solid/generated-vocab-', // TODO: SHOULD BE IRRELEVANT NOW (FOR VOCAB LIST FILES)...!?
   artifactName: 'common',
-  artifactVersion: VERSION_ARTIFACT_GENERATED,
   litVocabTermVersion: VERSION_LIT_VOCAB_TERM, // TODO: SHOULD BE IRRELEVANT NOW (FOR VOCAB LIST FILES)...!?
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -52,7 +48,6 @@ const GenerationConfigLitCore = {
   outputDirectory: '../../../../Solid/MonoRepo/testLit/packages/Vocab/LIT/Core',
   moduleNamePrefix: '@lit/generated-vocab-',
   artifactName: 'core',
-  artifactVersion: VERSION_ARTIFACT_GENERATED,
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
   runMavenInstall: RUN_MAVEN_INSTALL,
@@ -65,7 +60,7 @@ const GenerationConfigSolidComponent = {
     '../../../../Solid/MonoRepo/testLit/packages/Vocab/SolidComponent/Vocab/SolidComponent.ttl',
   ],
   outputDirectory: '../../../../Solid/MonoRepo/testLit/packages/Vocab/SolidComponent',
-  artifactVersion: VERSION_ARTIFACT_GENERATED,
+  artifactVersion: '0.1.0',
   moduleNamePrefix: '@solid/generated-vocab-',
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -79,7 +74,7 @@ const GenerationConfigSolidGeneratorUi = {
     '../../../../Solid/MonoRepo/testLit/packages/Vocab/SolidGeneratorUi/Vocab/SolidGeneratorUi.ttl',
   ],
   outputDirectory: '../../../../Solid/MonoRepo/testLit/packages/Vocab/SolidGeneratorUi',
-  artifactVersion: VERSION_ARTIFACT_GENERATED,
+  artifactVersion: '0.1.0',
   moduleNamePrefix: '@solid/generated-vocab-',
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,

--- a/src/generator/ArtifactGenerator.js
+++ b/src/generator/ArtifactGenerator.js
@@ -98,6 +98,12 @@ class ArtifactGenerator {
     return FileGenerator.createPackagingFiles(this.artifactData, 'Javascript');
   }
 
+  /**
+   * This method can generate multiple artifacts for different programming languages (e.g. a Java JAR and an NPM
+   * module), each of which can be comprised of a bundle of RDF vocabs.
+   *
+   * @returns {Promise<*>}
+   */
   async generateFromVocabListFile() {
     logger(`Generating artifact from vocabulary list file: [${this.artifactData.vocabListFile}]`);
 
@@ -125,6 +131,10 @@ class ArtifactGenerator {
     });
     await Promise.all(directoryDeletionPromises);
 
+    // TODO: This code evolved from where we originally only had a list of
+    //  vocabs to generate from. But now we can create artifacts for multiple
+    //  programming languages. But this code was extended to provide the
+    //  language-specific details within this original vocab-iterating loop.
     const vocabGenerationPromises = generationDetails.vocabList.map(async vocabDetails => {
       // const vocabGenerationPromises = generationDetails.vocabList.map(vocabDetails => {
 
@@ -133,7 +143,10 @@ class ArtifactGenerator {
       this.artifactData.vocabTermsFrom = vocabDetails.termSelectionFile;
       this.artifactData.nameAndPrefixOverride = vocabDetails.nameAndPrefixOverride;
 
+      // Generate this vocab for each artifact we are generating for.
       const artifactPromises = generationDetails.artifactToGenerate.map(artifactDetails => {
+        this.artifactData.artifactVersion = artifactDetails.artifactVersion;
+
         this.artifactData.outputDirectoryForArtifact = `${this.artifactData.outputDirectory}${ARTIFACT_DIRECTORY_SOURCE_CODE}/${artifactDetails.artifactFolderName}`;
 
         // TODO: Currently we need to very explicitly add this Java-specific
@@ -178,6 +191,8 @@ class ArtifactGenerator {
 
     // Generate packaging details for each generated artifact.
     generationDetails.artifactToGenerate.forEach(artifactDetails => {
+      this.artifactData.artifactVersion = artifactDetails.artifactVersion;
+
       this.artifactData.outputDirectoryForArtifact = `${this.artifactData.outputDirectory}${ARTIFACT_DIRECTORY_SOURCE_CODE}/${artifactDetails.artifactFolderName}`;
       this.artifactData.javaPackageName = artifactDetails.javaPackageName;
       this.artifactData.npmModuleScope = artifactDetails.npmModuleScope;

--- a/src/generator/ArtifactGenerator.test.js
+++ b/src/generator/ArtifactGenerator.test.js
@@ -32,6 +32,11 @@ describe('Artifact Generator', () => {
       expect(packageOutput).toEqual(
         expect.stringContaining('"name": "@lit/generated-vocab-common-TEST",')
       );
+      expect(packageOutput).toEqual(expect.stringContaining('"version": "10.11.12"'));
+
+      const outputDirectoryJava = `${outputDirectory}${ARTIFACT_DIRECTORY_SOURCE_CODE}/Java`;
+      const pomOutput = fs.readFileSync(`${outputDirectoryJava}/pom.xml`).toString();
+      expect(pomOutput).toEqual(expect.stringContaining('<version>3.2.1-SNAPSHOT</version>'));
     }
 
     it('should fail with non-existent vocab list file', async () => {
@@ -55,7 +60,7 @@ describe('Artifact Generator', () => {
       const artifactGenerator = new ArtifactGenerator({
         vocabListFile: './test/resources/vocabs/vocab-list.yml',
         outputDirectory,
-        artifactVersion: '1.0.0',
+        // artifactVersion: '1.0.0',
         moduleNamePrefix: '@lit/generated-vocab-',
         noprompt: true,
       });

--- a/test/resources/vocabs/vocab-list.yml
+++ b/test/resources/vocabs/vocab-list.yml
@@ -6,17 +6,19 @@ artifactName: generated-vocab-common-TEST
 
 artifactToGenerate:
   - programmingLanguage: Java
+    artifactVersion: 3.2.1-SNAPSHOT
     javaPackageName: com.inrupt.testing
     litVocabTermVersion: "0.1.0-SNAPSHOT"
     artifactFolderName: Java
     handlebarsTemplate: java-rdf4j.hbs
     sourceFileExtension: java
-    # Currently we're just adding terms as the occur in vocabs, and not all possible keywords.
+    # Currently we're just adding terms as they occur in vocabs, and not all possible keywords.
     languageKeywordsToUnderscore:
       - class     # Defined in VCard.
       - abstract  # Defined in DCTerms.
 
   - programmingLanguage: Javascript
+    artifactVersion: 10.11.12
     npmModuleScope: "@lit/"
     litVocabTermVersion: "^1.0.10"
     artifactFolderName: Javascript


### PR DESCRIPTION
…ordingly.

Also did a little bit of tidying up of comments and variable names (to be more consistent). Notice that the YAML files use the key 'termSelectionFile' though, whereas our code now uses 'vocabsTermsFrom'. I think we should just use 'onlyVocabsTermsFrom' everywhere - but I'll create a separate issue for that!