### PR TITLE
Removed artifact type selection from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ lit-artifact-generator --help
 node index.js generate --inputResources <ontology resources (e.g. local files, or remote IRI's)>
 ```
 
-The output is a Node Module containing a Javascript file with constants defined for the RDF terms found in the vocabulary (or multiple vocabularies) specified by the 'inputResources' flag. This module is located inside the **./generated** folder by default.
+The output is a Node Module containing a Javascript file with constants defined for the RDF terms found in the vocabulary (or multiple vocabularies) specified by the 'inputResources' flag. This module is located inside the **./generated** folder by default. To generate artifacts in a different language, a YAML configuration file must be used (see below).
 
 
 - To **initialize** a YAML file that should be edited manually

--- a/index.js
+++ b/index.js
@@ -81,11 +81,6 @@ const yargsConfig = yargs
         .describe('artifactVersion', 'The version of the artifact(s) to be generated.')
         .default('artifactVersion', '0.0.1')
 
-        .alias('at', 'artifactType')
-        .describe('artifactType', 'The artifact type that will be generated.')
-        .choices('artifactType', ['nodejs', 'java']) // Add to this when other languages are supported.
-        .default('artifactType', 'nodejs')
-
         .alias('mnp', 'moduleNamePrefix')
         .describe('moduleNamePrefix', 'A prefix for the name of the output module')
         .default('moduleNamePrefix', '@lit/generated-vocab-')


### PR DESCRIPTION
Resolves #77 

The CLI only allows the creation of Node artifacts, so there should not be a CLI option to select a different artifact type.