### PR TITLE
Feature/137 last modif date undefined

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -97,17 +97,10 @@ module.exports = class Resource {
     return axios({
       method: 'head',
       url: resource,
-    })
-      .then(response => {
-        const lastModifiedDate = Date.parse(response.headers['last-modified']);
-        if (Number.isNaN(lastModifiedDate)) {
-          throw new Error(`Cannot parse date: [${lastModifiedDate}]`);
-        }
-        return lastModifiedDate;
-      })
-      .catch(error => {
-        throw new Error(`Cannot get last modification time: [${error}] for resource [${resource}]`);
-      });
+    }).then(response => {
+      const lastModifiedDate = Date.parse(response.headers['last-modified']);
+      return Number.isNaN(lastModifiedDate) ? DEFAULT_MODIFICATION_DATE : lastModifiedDate;
+    });
   }
 
   /**

--- a/src/Resource.test.js
+++ b/src/Resource.test.js
@@ -40,7 +40,9 @@ describe('Resources last modification', () => {
     axios.mockImplementation(
       jest.fn().mockReturnValue(Promise.resolve(INVALID_LAST_MODIF_HTTP_RESOURCE))
     );
-    const lastModificationTime = await Resource.getResourceLastModificationTime('http://whatever.org');
+    const lastModificationTime = await Resource.getResourceLastModificationTime(
+      'http://whatever.org'
+    );
     expect(lastModificationTime).toEqual(Resource.DEFAULT_MODIFICATION_DATE);
   });
 });


### PR DESCRIPTION
Resolves issue  #137 

If an online resource does not define a Last-Modified value, a default value is returned. This default value is ancient enough to necessarily trigger the re-generation of artifacts.