### PR TITLE
Added a validation for the YAML file

### DIFF
--- a/src/config/GeneratorConfiguration.js
+++ b/src/config/GeneratorConfiguration.js
@@ -133,6 +133,18 @@ class GeneratorConfiguration {
   }
 
   /**
+   * This function checks the validity of artifacts objects as found in the artifactToGenerate list
+   * @param {*} artifact the configuration object for an individual artifact
+   */
+  static validateArtifact(artifact) {
+    if (!artifact.artifactDirectoryName) {
+      throw new Error(
+        `The target directory name for the [${artifact.programmingLanguage}] artifact is missing. Please set a value for 'artifactDirectoryName'.`
+      );
+    }
+  }
+
+  /**
    * Validates if all the required values are present in the config file, and throws an error otherwise.
    * @param {Object} config the object loaded from the YAML config
    * @param {string} file the path to the YAML file, for error message purpose
@@ -144,6 +156,9 @@ class GeneratorConfiguration {
         'No artifacts found: nothing to generate. ' +
           `Please edit the YAML configuration file [${file}] to provide artifacts to be generated.`
       );
+    }
+    for (let i = 0; i < config.artifactToGenerate.length; i += 1) {
+      GeneratorConfiguration.validateArtifact(config.artifactToGenerate[i]);
     }
     // There must be at least one vocabulary defined
     if (!config.vocabList) {

--- a/src/config/GeneratorConfiguration.test.js
+++ b/src/config/GeneratorConfiguration.test.js
@@ -45,6 +45,13 @@ describe('Generator configuration', () => {
       }).toThrow('Failed to read configuration file');
     });
 
+    it('should fail with missing artifactDirectoryName in YAML vocab list file', async () => {
+      const notYamlFile = './test/resources/vocabs/vocab-list-missing-artifactDirectoryName.yml';
+      await expect(() => {
+        GeneratorConfiguration.fromYaml(notYamlFile);
+      }).toThrow('The target directory name ');
+    });
+
     it('should throw an error trying to parse an empty YAML file', async () => {
       const configFile = 'empty-config-file.yml';
       const configPath = `./test/resources/vocabs/${configFile}`;

--- a/test/resources/vocabs/vocab-list-missing-artifactDirectoryName.yml
+++ b/test/resources/vocabs/vocab-list-missing-artifactDirectoryName.yml
@@ -1,0 +1,50 @@
+#
+# This file contains a simple list of vocabularies that we bundle together to
+# form the collective set vocabularies within a single artifact.
+#
+artifactName: generated-vocab-common-TEST
+
+artifactToGenerate:
+  - programmingLanguage: Java
+    artifactVersion: 3.2.1-SNAPSHOT
+    javaPackageName: com.inrupt.testing
+    litVocabTermVersion: "0.1.0-SNAPSHOT"
+    artifactFolderName: Java
+    handlebarsTemplate: java-rdf4j.hbs
+    sourceFileExtension: java
+    # Currently we're just adding terms as they occur in vocabs, and not all possible keywords.
+    languageKeywordsToUnderscore:
+      - class     # Defined in VCard.
+      - abstract  # Defined in DCTerms.
+    packaging:
+      - packagingTool: maven
+        groupId: com.inrupt.test
+        packagingTemplates: 
+        - template: pom.hbs
+          fileName: pom.xml
+
+  - programmingLanguage: Javascript
+    artifactVersion: 10.11.12
+    npmModuleScope: "@lit/"
+    litVocabTermVersion: "^1.0.10"
+    handlebarsTemplate: javascript-rdf-ext.hbs
+    sourceFileExtension: js
+    packaging: 
+      - packagingTool: npm 
+        npmModuleScope: "@lit/"
+        packagingTemplates: 
+          - template: package.hbs
+            fileName: package.json
+          - template: index.hbs
+            fileName: index.js
+
+vocabList:
+  - description: Snippet of Schema.org from Google, Microsoft, Yahoo and Yandex
+    inputResources:
+      - ./schema-snippet.ttl
+    termSelectionFile: schema-inrupt-ext.ttl
+
+  - description: Vocab for testing predicate types...
+    nameAndPrefixOverride: override-name
+    inputResources:
+      - ./supported-data-types.ttl


### PR DESCRIPTION
After changing the `artifactFolderName` option to `artifactDirectoryName`, we realized that the absence of `artifactDirectoryName` in the YAML file led to a failure with an error message conveying little information. This fix introduces a proper validation with a clearer failure message.