### PR TITLE
Removed support for 'enabled' flag, and reinstated 100% code coverage

### DIFF
--- a/src/config/GeneratorConfiguration.js
+++ b/src/config/GeneratorConfiguration.js
@@ -154,18 +154,16 @@ class GeneratorConfiguration {
       normalizedArtifactConfig.packaging = normalizedArtifactConfig.packaging.map(
         packagingConfig => {
           const normalizedPackagingConfig = packagingConfig;
-          if (packagingConfig.packagingTemplates) {
-            normalizedPackagingConfig.packagingTemplates = packagingConfig.packagingTemplates.map(
-              packagingTemplate => {
-                const normalizedPackagingTemplate = packagingTemplate;
-                normalizedPackagingTemplate.template = GeneratorConfiguration.normalizeTemplatePath(
-                  packagingTemplate.template,
-                  normalizedYamlPath
-                );
-                return normalizedPackagingTemplate;
-              }
-            );
-          }
+          normalizedPackagingConfig.packagingTemplates = packagingConfig.packagingTemplates.map(
+            packagingTemplate => {
+              const normalizedPackagingTemplate = packagingTemplate;
+              normalizedPackagingTemplate.template = GeneratorConfiguration.normalizeTemplatePath(
+                packagingTemplate.template,
+                normalizedYamlPath
+              );
+              return normalizedPackagingTemplate;
+            }
+          );
           return normalizedPackagingConfig;
         }
       );
@@ -249,6 +247,15 @@ class GeneratorConfiguration {
       throw new Error(
         `The target directory name for the [${artifact.programmingLanguage}] artifact is missing. Please set a value for 'artifactDirectoryName'.`
       );
+    }
+    if (artifact.packaging) {
+      artifact.packaging.forEach(packagingConfig => {
+        if (!packagingConfig.packagingTemplates) {
+          throw new Error(
+            `No templates associated to packaging tool [${packagingConfig.packagingTool}]`
+          );
+        }
+      });
     }
   }
 

--- a/src/config/GeneratorConfiguration.test.js
+++ b/src/config/GeneratorConfiguration.test.js
@@ -90,6 +90,15 @@ describe('Generator configuration', () => {
       }).toThrow(/No artifacts found/, configFile);
     });
 
+    it('should fail if a packaging system does not provide any templates', async () => {
+      const configPath = `./test/resources/packaging/vocab-list-no-packaging-templates.yml`;
+
+      // Test that the error message contains the expected explanation and file name
+      await expect(() => {
+        GeneratorConfiguration.fromYaml(configPath);
+      }).toThrow('No templates associated to packaging tool');
+    });
+
     // SUCCESS CASE
     it('should generate collected configuration from vocab list file', async () => {
       const generatorConfiguration = new GeneratorConfiguration(

--- a/src/config/artifacts/JavaArtifactConfigurator.js
+++ b/src/config/artifacts/JavaArtifactConfigurator.js
@@ -125,7 +125,6 @@ class JavaArtifactConfigurator extends ArtifactConfigurator {
       if (!mavenConfig.repository) {
         mavenConfig.repository = [];
       }
-      // The repository is enabled by default
       mavenConfig.repository.push({
         // eslint-disable-next-line no-await-in-loop
         ...(await inquirer.prompt(MAVEN_REPOSITORY_PROMPT)),

--- a/src/generator/ConfigFileGenerator.js
+++ b/src/generator/ConfigFileGenerator.js
@@ -48,7 +48,7 @@ function validateLanguageCheckboxes(answer) {
     // This mismatch in return types is expected by inquirer.
     return 'You must choose at least one target language.';
   }
-  
+
   return true;
 }
 
@@ -65,7 +65,7 @@ function validateRepositoryCheckboxes(answer) {
     // This mismatch in return types is expected by inquirer
     return 'You must choose at most one repository type.';
   }
-  
+
   return true;
 }
 
@@ -119,7 +119,7 @@ class ConfigFileGenerator {
       // for language-specific config generator.
       return new SUPPORTED_LANGUAGES[language]();
     }
-    
+
     throw new Error(`Unsported language: no config generator is registered for [${language}]`);
   }
 
@@ -141,7 +141,7 @@ class ConfigFileGenerator {
         ];
       }
     }
-    
+
     // If the type is not set, return null to avoid adding an empty element to the target
     // configuration object.
     return repositoryConfig.type ? repositoryConfig : null;
@@ -160,7 +160,7 @@ class ConfigFileGenerator {
       // and therefore implement the 'prompt()' method.
       artifacts.push(await generator.prompt()); // eslint-disable-line no-await-in-loop
     }
-    
+
     return artifacts;
   }
 
@@ -180,7 +180,7 @@ class ConfigFileGenerator {
       vocabularies.push(await VocabularyConfigurator.prompt()); // eslint-disable-line no-await-in-loop
       addVocab = await inquirer.prompt(ADD_VOCABULARY_CONFIRMATION); // eslint-disable-line no-await-in-loop
     }
-    
+
     return vocabularies;
   }
 
@@ -198,7 +198,7 @@ class ConfigFileGenerator {
     // Collect the different artifacts to generate in a map containing only one key-value pair.
     const languages = await inquirer.prompt(LANGUAGES_CHECKBOXES);
     this.config.artifactToGenerate = await ConfigFileGenerator.promptArtifacts(languages.languages);
-    
+
     // Get vocabulary information.
     this.config.vocabList = await ConfigFileGenerator.promptVocabularies();
   }
@@ -241,8 +241,5 @@ class ConfigFileGenerator {
 
 module.exports.ConfigFileGenerator = ConfigFileGenerator;
 module.exports.validateLanguageCheckboxes = validateLanguageCheckboxes;
-<<<<<<< HEAD
 module.exports.validateRepositoryCheckboxes = validateRepositoryCheckboxes;
-=======
 module.exports.DEFAULT_CONFIG_TEMPLATE_PATH = DEFAULT_CONFIG_TEMPLATE_PATH;
->>>>>>> Made it possible to have custom templates relative to the yaml file

--- a/src/generator/FileGenerator.js
+++ b/src/generator/FileGenerator.js
@@ -134,7 +134,7 @@ class FileGenerator {
     if (generalInfo.versioning && generalInfo.versioning.associatedFiles) {
       generalInfo.versioning.associatedFiles.forEach(associatedFile => {
         FileGenerator.createFileFromTemplate(
-          path.join('..', '..', 'templates', associatedFile.template),
+          path.join(associatedFile.template),
           generalInfo,
           path.join(generalInfo.outputDirectory, ARTIFACT_DIRECTORY_ROOT, associatedFile.fileName)
         );

--- a/templates/empty-config.hbs
+++ b/templates/empty-config.hbs
@@ -60,9 +60,8 @@ artifactToGenerate:
         {{#if repository}}
         repository:
           {{#each repository}}
-          - enabled: {{enabled}}
             {{#if type}}
-            type: {{type}}
+            - type: {{type}}
             {{/if}}
             {{#if id}}
             id: {{id}}
@@ -76,8 +75,7 @@ artifactToGenerate:
     {{/if}}
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/templates/initial-config.hbs
+++ b/templates/initial-config.hbs
@@ -20,8 +20,7 @@ artifactToGenerate:
       - class     # Defined in VCard.
       - abstract  # Defined in DCTerms.
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 
@@ -33,10 +32,6 @@ artifactToGenerate:
     artifactDirectoryName: Javascript
     handlebarsTemplate: javascript-rdf-ext.hbs
     sourceFileExtension: js
-#    repository:
-#      - enabled: true
-#        registry: http://localhost:4873/
-
 
 vocabList:
 #  # Example of an online vocabulary.

--- a/templates/package.hbs
+++ b/templates/package.hbs
@@ -17,15 +17,6 @@
     "url": "{{versioning.url}}"
   },
 {{/if}}
-{{#if repository}}
-  {{#each repository}}
-    {{#if enabled}}
-  "publishConfig": {
-    "registry": "{{registry}}"
-  },
-    {{/if}}
- {{/each}}
-{{/if}}
   "dependencies": {
     "@lit/vocab-term": "{{litVocabTermVersion}}"
   }{{#if supportBundling}},

--- a/templates/pom.hbs
+++ b/templates/pom.hbs
@@ -30,12 +30,10 @@
 {{#if repository}}
     <distributionManagement>
     {{#each repository}}
-        {{#if enabled}}
         <{{type}}>
             <id>{{id}}</id>
             <url>{{url}}</url>
         </{{type}}>
-        {{/if}}
     {{/each}}
     </distributionManagement>
 {{/if}}

--- a/test/resources/backwardCompatibility/vocab-list_no-packaging.yml
+++ b/test/resources/backwardCompatibility/vocab-list_no-packaging.yml
@@ -35,12 +35,10 @@ artifactToGenerate:
       # No packaging options are explitely set, as the generator initially generated Maven artifacts only for Java code
       ##
     repository:
-      - enabled: true
-        type: repository
+      - type: repository
         id: nexus-releases
         url: https://nexus.inrupt.com/repository/maven-releases/
-      - enabled: true
-        type: snapshotRepository
+      - type: snapshotRepository
         id: nexus-snapshots
         url: https://nexus.inrupt.com/repository/maven-snapshots/
 
@@ -52,11 +50,6 @@ artifactToGenerate:
     artifactDirectoryName: Javascript
     handlebarsTemplate: javascript-rdf-ext.hbs
     sourceFileExtension: js
-    repository:
-      - enabled: true
-        registry: http://localhost:4873/
-      - enabled: false
-        registry: https://verdaccio.inrupt.com/
   ##
   #  This is a dummy artifact that cannot be packaged
   ##

--- a/test/resources/expectedOutputs/default-lit-vocab.yml
+++ b/test/resources/expectedOutputs/default-lit-vocab.yml
@@ -20,8 +20,7 @@ artifactToGenerate:
       - class     # Defined in VCard.
       - abstract  # Defined in DCTerms.
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 
@@ -33,10 +32,6 @@ artifactToGenerate:
     artifactDirectoryName: Javascript
     handlebarsTemplate: javascript-rdf-ext.hbs
     sourceFileExtension: js
-#    repository:
-#      - enabled: true
-#        registry: http://localhost:4873/
-
 
 vocabList:
 #  # Example of an online vocabulary.

--- a/test/resources/expectedOutputs/lit-vocab-git.yml
+++ b/test/resources/expectedOutputs/lit-vocab-git.yml
@@ -28,8 +28,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/expectedOutputs/lit-vocab-svn.yml
+++ b/test/resources/expectedOutputs/lit-vocab-svn.yml
@@ -25,8 +25,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/expectedOutputs/lit-vocab.yml
+++ b/test/resources/expectedOutputs/lit-vocab.yml
@@ -22,8 +22,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/normalization/vocab-list.yml
+++ b/test/resources/normalization/vocab-list.yml
@@ -1,0 +1,37 @@
+artifactName: generated-vocab-common-TEST
+
+artifactToGenerate:
+  - programmingLanguage: Java
+    artifactVersion: 3.2.1-SNAPSHOT
+    javaPackageName: com.inrupt.testing
+    artifactDirectoryName: Java
+    ##
+    # Here the template is picked among the default options
+    ##
+    handlebarsTemplate: java-rdf4j.hbs
+    sourceFileExtension: java
+    packaging:
+      - packagingTool: maven
+        groupId: com.inrupt.test
+        packagingTemplates: 
+        - template: pom.hbs
+          fileName: pom.xml
+        ##
+        # This is a dummy file path, just here to test normalization
+        ##
+        - template: ../../readme.hbs
+          fileName: pom.xml
+
+  - programmingLanguage: Javascript
+    artifactDirectoryName: Javascript
+    ##
+    # This is a dummy file path, just here to test normalization
+    ##
+    handlebarsTemplate: ../anotherTemplateDirectory/javascript.hbs
+    sourceFileExtension: js
+
+vocabList:
+  - description: Snippet of Schema.org from Google, Microsoft, Yahoo and Yandex
+    inputResources:
+      - ./schema-snippet.ttl
+    termSelectionResource: schema-inrupt-ext.ttl

--- a/test/resources/packaging/vocab-list-no-packaging-templates.yml
+++ b/test/resources/packaging/vocab-list-no-packaging-templates.yml
@@ -1,0 +1,24 @@
+artifactName: generated-vocab-common-TEST
+
+artifactToGenerate:
+  - programmingLanguage: Java
+    artifactVersion: 3.2.1-SNAPSHOT
+    javaPackageName: com.inrupt.testing
+    litVocabTermVersion: "0.1.0-SNAPSHOT"
+    artifactDirectoryName: Java
+    handlebarsTemplate: java-rdf4j.hbs
+    sourceFileExtension: java
+    packaging:
+      - packagingTool: maven
+        groupId: com.inrupt.test
+        ##
+        #  These templates should be present
+        ##
+#       packagingTemplates: 
+#       - template: pom.hbs
+#         fileName: pom.xml
+
+vocabList:
+  - description: Snippet of Schema.org from Google, Microsoft, Yahoo and Yandex
+    inputResources:
+      - ../vocabs/schema-snippet.ttl

--- a/test/resources/packaging/vocab-list-repository.yml
+++ b/test/resources/packaging/vocab-list-repository.yml
@@ -26,12 +26,10 @@ artifactToGenerate:
         - template: pom.hbs
           fileName: pom.xml
         repository:
-        - enabled: true
-          type: repository
+        - type: repository
           id: nexus-releases
           url: https://nexus.inrupt.com/repository/maven-releases/
-        - enabled: true
-          type: snapshotRepository
+        - type: snapshotRepository
           id: nexus-snapshots
           url: https://nexus.inrupt.com/repository/maven-snapshots/
 #      - packagingTool: gradle

--- a/test/resources/validation/missing-local-vocab-list.yml
+++ b/test/resources/validation/missing-local-vocab-list.yml
@@ -21,8 +21,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/validation/vocab-list-containing-invalid-syntax.yml
+++ b/test/resources/validation/vocab-list-containing-invalid-syntax.yml
@@ -21,8 +21,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/validation/vocab-list.yml
+++ b/test/resources/validation/vocab-list.yml
@@ -21,8 +21,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/versioning/vocab-list.yml
+++ b/test/resources/versioning/vocab-list.yml
@@ -28,8 +28,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/watcher/vocab-list-including-online.yml
+++ b/test/resources/watcher/vocab-list-including-online.yml
@@ -22,8 +22,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/

--- a/test/resources/watcher/vocab-list.yml
+++ b/test/resources/watcher/vocab-list.yml
@@ -22,8 +22,7 @@ artifactToGenerate:
     javaPackageName: "com.example.java.packagename"
 #    gitRepository: git@github.com:some_user/some_project.git
 #    repository:
-#      - enabled: true
-#        type: repository
+#      - type: repository
 #        id: nexus-releases
 #        url: https://nexus.mycompany.com/repository/maven-releases/
 #        registry: http://localhost:4873/


### PR DESCRIPTION
Resolves #179 

- Remove the 'enabled' flag from tests YAML and templates
  - Since only one registry may be specified in the package.json publishConfig, having multiple registries without explicitely enabling one may lead to conflicts. That is why registries have been removed altogether from the package.json template.
- Fixed a merging issue
- Reached 100% code coverage for versioning management in templates