### PR TITLE
Clarified the failure in case of empty vocabs

### DIFF
--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -204,11 +204,6 @@ module.exports = class DatasetHandler {
     result.versionBabelCore = this.vocabData.versionBabelCore;
     result.versionBabelLoader = this.vocabData.versionBabelLoader;
 
-    // These values come from the artifact-specific configuration.
-    result.javaPackageName = this.vocabData.javaPackageName;
-    result.npmModuleScope = this.vocabData.npmModuleScope;
-    result.litVocabTermVersion = this.vocabData.litVocabTermVersion;
-
     result.generatedTimestamp = this.vocabData.generatedTimestamp;
     result.generatorName = this.vocabData.generatorName;
     result.generatorVersion = this.vocabData.generatorVersion;
@@ -248,6 +243,9 @@ module.exports = class DatasetHandler {
     let subjectSet = DatasetHandler.subjectsOnly(this.subjectsOnlyDataset);
     if (subjectSet.length === 0) {
       subjectSet = DatasetHandler.subjectsOnly(this.fullDataset);
+    }
+    if (subjectSet.length === 1 && subjectSet[0] === result.namespace) {
+      throw new Error(`[${result.namespace}] does not contain any terms.`);
     }
 
     subjectSet.forEach(subject => {

--- a/src/DatasetHandler.test.js
+++ b/src/DatasetHandler.test.js
@@ -114,4 +114,22 @@ describe('Dataset Handler', () => {
     });
     expect(handler.findPreferredNamespacePrefix()).toEqual('foaf');
   });
+
+  it('should throw an error if the vocabulary does not define any term', () => {
+    const NS = 'http://xmlns.com/foaf/0.1/';
+    const NS_IRI = rdf.namedNode(NS);
+
+    const vocab = rdf
+      .dataset()
+      .addAll([
+        rdf.quad(NS_IRI, RDF.type, OWL.Ontology),
+        rdf.quad(NS_IRI, VANN.preferredNamespaceUri, NS_IRI),
+      ]);
+    const handler = new DatasetHandler(vocab, rdf.dataset(), {
+      inputResources: ['does not matter'],
+    });
+    expect(() => {
+      handler.buildTemplateInput();
+    }).toThrow(`[${NS}] does not contain any terms.`);
+  });
 });

--- a/src/generator/VocabGenerator.test.js
+++ b/src/generator/VocabGenerator.test.js
@@ -85,20 +85,20 @@ const datasetExtension = rdf
   ]);
 
 const extSubject = rdf.namedNode('http://rdf-extension.com');
-const owlOntologyDataset = rdf
-  .dataset()
-  .addAll([
-    rdf.quad(extSubject, RDF.type, OWL.Ontology),
-    rdf.quad(extSubject, RDFS.label, rdf.literal('Extension label')),
-    rdf.quad(extSubject, DCTERMS.creator, rdf.literal('Jarlath Holleran')),
-    rdf.quad(
-      extSubject,
-      DCTERMS.description,
-      rdf.literal("Extension comment with special ' character!")
-    ),
-    rdf.quad(extSubject, VANN.preferredNamespacePrefix, rdf.literal('ext-prefix')),
-    rdf.quad(extSubject, VANN.preferredNamespaceUri, rdf.literal('http://rdf-extension.com')),
-  ]);
+const owlOntologyDataset = rdf.dataset().addAll([
+  rdf.quad(extSubject, RDF.type, OWL.Ontology),
+  rdf.quad(extSubject, RDFS.label, rdf.literal('Extension label')),
+  rdf.quad(extSubject, DCTERMS.creator, rdf.literal('Jarlath Holleran')),
+  rdf.quad(
+    extSubject,
+    DCTERMS.description,
+    rdf.literal("Extension comment with special ' character!")
+  ),
+  rdf.quad(extSubject, VANN.preferredNamespacePrefix, rdf.literal('ext-prefix')),
+  rdf.quad(extSubject, VANN.preferredNamespaceUri, rdf.literal('http://rdf-extension.com')),
+  // This triple prevents the dataset from not defining any terms
+  rdf.quad(rdf.namedNode('http://rdf-extension.com/dummyClass'), RDF.type, OWL.Class),
+]);
 
 const emptyDataSet = rdf.dataset();
 
@@ -702,14 +702,14 @@ describe('Artifact generator unit tests', () => {
     });
 
     it('should default description to empty string if rdfs:comment of an owl:Ontology term is not found', () => {
-      const owlOntologyDatasetWithNoComment = rdf
-        .dataset()
-        .addAll([
-          rdf.quad(extSubject, RDF.type, OWL.Ontology),
-          rdf.quad(extSubject, RDFS.label, rdf.literal('Extension label')),
-          rdf.quad(extSubject, VANN.preferredNamespacePrefix, rdf.literal('ext-prefix')),
-          rdf.quad(extSubject, VANN.preferredNamespaceUri, rdf.literal('http://rdf-extension.com')),
-        ]);
+      const owlOntologyDatasetWithNoComment = rdf.dataset().addAll([
+        rdf.quad(extSubject, RDF.type, OWL.Ontology),
+        rdf.quad(extSubject, RDFS.label, rdf.literal('Extension label')),
+        rdf.quad(extSubject, VANN.preferredNamespacePrefix, rdf.literal('ext-prefix')),
+        rdf.quad(extSubject, VANN.preferredNamespaceUri, rdf.literal('http://rdf-extension.com')),
+        // This triple prevents the dataset from not defining any terms
+        rdf.quad(rdf.namedNode('http://rdf-extension.com/dummyClass'), RDF.type, OWL.Class),
+      ]);
 
       const result = vocabGenerator.buildTemplateInput(
         VocabGenerator.merge([dataset, owlOntologyDatasetWithNoComment]),
@@ -732,15 +732,15 @@ describe('Artifact generator unit tests', () => {
     });
 
     it('should default to lit-js@inrupt.com if authors in not contained in owl:Ontology terms', () => {
-      const owlOntologyDatasetWithNoAuthor = rdf
-        .dataset()
-        .addAll([
-          rdf.quad(extSubject, RDF.type, OWL.Ontology),
-          rdf.quad(extSubject, RDFS.label, rdf.literal('Extension label')),
-          rdf.quad(extSubject, RDFS.comment, rdf.literal('Extension comment')),
-          rdf.quad(extSubject, VANN.preferredNamespacePrefix, rdf.literal('ext-prefix')),
-          rdf.quad(extSubject, VANN.preferredNamespaceUri, rdf.literal('http://rdf-extension.com')),
-        ]);
+      const owlOntologyDatasetWithNoAuthor = rdf.dataset().addAll([
+        rdf.quad(extSubject, RDF.type, OWL.Ontology),
+        rdf.quad(extSubject, RDFS.label, rdf.literal('Extension label')),
+        rdf.quad(extSubject, RDFS.comment, rdf.literal('Extension comment')),
+        rdf.quad(extSubject, VANN.preferredNamespacePrefix, rdf.literal('ext-prefix')),
+        rdf.quad(extSubject, VANN.preferredNamespaceUri, rdf.literal('http://rdf-extension.com')),
+        // This triple prevents the dataset from not defining any terms
+        rdf.quad(rdf.namedNode('http://rdf-extension.com/dummyClass'), RDF.type, OWL.Class),
+      ]);
       const result = vocabGenerator.buildTemplateInput(
         VocabGenerator.merge([dataset, owlOntologyDatasetWithNoAuthor]),
         VocabGenerator.merge([owlOntologyDatasetWithNoAuthor])


### PR DESCRIPTION
Resolves #182

If a vocabulary does not define any terms, and only has himself as a subject (e.g. ':vocab a owl:Ontology'), then the generator fails with an explicit message.