### PR TITLE
Updated the version number and the associated documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit/artifact-generator",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A generator for building artifacts (e.g. Java JARs, NPM modules, etc.) from RDF vocabularies.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
To make the documentation more 'developer-friendly' (i.e. how I think I would like finding it), I detailed how the YAML file should be used by inserting comments into a valid YAML file, which can be copy-pasted to be integrated into an actual configuration. 