### PR TITLE
Enabled use of 'namespaceOverride' option

### DIFF
--- a/src/DatasetHandler.test.js
+++ b/src/DatasetHandler.test.js
@@ -132,4 +132,20 @@ describe('Dataset Handler', () => {
       handler.buildTemplateInput();
     }).toThrow(`[${NS}] does not contain any terms.`);
   });
+
+  it('should override the namespace of the terms', () => {
+    const namespaceOverride = 'https://override.namespace.org';
+    const testTermClass = `${NAMESPACE}testTermClass`;
+    const dataset = rdf
+      .dataset()
+      .addAll(vocabMetadata)
+      .addAll([rdf.quad(rdf.namedNode(testTermClass), RDF.type, RDFS.Class)]);
+
+    const handler = new DatasetHandler(dataset, rdf.dataset(), {
+      inputResources: ['does not matter'],
+      namespaceOverride,
+    });
+    const result = handler.buildTemplateInput();
+    expect(result.namespace).toEqual(namespaceOverride);
+  });
 });

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -41,9 +41,6 @@ module.exports = class Resource {
    *
    * @param datasetFiles
    * @param termSelectionResource
-   * @param fileResourcesRelativeTo If we load resources locally from the file system, make them relative to this path
-   * (e.g. for reading resources from a vocab list file that can be anywhere, all local resources referenced in it
-   * should be relative to wherever that list file itself is!).
    */
   constructor(datasetFiles, termSelectionResource) {
     this.datasetFiles = datasetFiles;

--- a/test/resources/yamlConfig/namespace-override.yml
+++ b/test/resources/yamlConfig/namespace-override.yml
@@ -1,0 +1,48 @@
+#
+# This file contains a simple list of vocabularies that we bundle together to
+# form the collective set vocabularies within a single artifact.
+#
+artifactName: generated-vocab-common-TEST
+artifactGeneratorVersion: 0.1.0
+
+artifactToGenerate:
+  - programmingLanguage: Java
+    artifactVersion: 3.2.1-SNAPSHOT
+    javaPackageName: com.inrupt.testing
+    litVocabTermVersion: "0.1.0-SNAPSHOT"
+    artifactDirectoryName: Java
+    handlebarsTemplate: java-rdf4j.hbs
+    sourceFileExtension: java
+    # Currently we're just adding terms as they occur in vocabs, and not all possible keywords.
+    languageKeywordsToUnderscore:
+      - class     # Defined in VCard.
+      - abstract  # Defined in DCTerms.
+    packaging:
+      - packagingTool: maven
+        groupId: com.inrupt.test
+        packagingTemplates: 
+        - template: pom.hbs
+          fileName: pom.xml
+
+  - programmingLanguage: Javascript
+    artifactVersion: 10.11.12
+    npmModuleScope: "@lit/"
+    litVocabTermVersion: "^1.0.10"
+    artifactDirectoryName: Javascript
+    handlebarsTemplate: javascript-rdf-ext.hbs
+    sourceFileExtension: js
+    packaging: 
+      - packagingTool: npm 
+        npmModuleScope: "@lit/"
+        packagingTemplates: 
+          - template: package.hbs
+            fileName: package.json
+          - template: index.hbs
+            fileName: index.js
+
+vocabList:
+  - description: Snippet of Schema.org from Google, Microsoft, Yahoo and Yandex
+    inputResources:
+      - ../vocabs/schema-snippet.ttl
+    termSelectionResource: ../vocabs/schema-inrupt-ext.ttl
+    namespaceOverride: https://override.schema.org/


### PR DESCRIPTION
Resolves #219 

The use of namespaceOverride was recognized as a typo in the namespace, and prevented splitting the terms between the namespace and their local name (the last part of the path or the fragment). This is now fixed.