### PR TITLE
ESS-135: Added prefix and suffix support for JS templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/lit-artifact-generator",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A generator for building artifacts (e.g. Java JARs, NPM modules, etc.) from RDF vocabularies.",
   "main": "index.js",
   "bin": {

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -69,11 +69,11 @@ module.exports = class DatasetHandler {
 
     // The namespace can manually be overridden in the configuration file.
     if (!fullName.startsWith(namespace) && !fullName.startsWith(this.vocabData.namespaceOverride)) {
-      // ...but some vocabs reference terms from other very common 
+      // ...but some vocabs reference terms from other very common
       // vocabs (like ActivityStreams 2.0 having the following two triples:
       //   rdf:langString a rdfs:Datatype .
       //   xsd:duration a rdfs:Datatype .
-      // ...that are referring to terms from the RDF and XML Schema 
+      // ...that are referring to terms from the RDF and XML Schema
       // vocabularies)! For terms from these very common vocabs, simply
       // ignore them...
       if (
@@ -104,7 +104,7 @@ module.exports = class DatasetHandler {
       splitIri = fullName.split(this.vocabData.namespaceOverride);
     }
     const name = splitIri[1];
-    
+
     const nameEscapedForLanguage = name
       .replace(/-/g, '_')
       // TODO: Currently these alterations are required only for Java-specific

--- a/templates/package-rdflib.hbs
+++ b/templates/package-rdflib.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{npmModuleScope}}{{artifactName}}",
+  "name": "{{npmModuleScope}}{{artifactPrefix}}{{artifactName}}{{artifactSuffix}}",
   "version": "{{artifactVersion}}",
   "description": "{{description}}",
   "main": "index.js",

--- a/templates/package.hbs
+++ b/templates/package.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{npmModuleScope}}{{artifactName}}",
+  "name": "{{npmModuleScope}}{{artifactPrefix}}{{artifactName}}{{artifactSuffix}}",
   "version": "{{artifactVersion}}",
   "description": "{{description}}",
   "main": "index.js",


### PR DESCRIPTION
This enables having a prefix and/or a suffix to distinguish the different JS packages generated for the same artifact (e.g. `lit-common-rdflib` and `lit-common-rdf-ext`). It is also useful to have a different artifact id from Maven to NPM, that is why it is useful for ESS-135.