### PR TITLE
The TS package.json file declares sideEffects to false

### DIFF
--- a/templates/typescript/package.hbs
+++ b/templates/typescript/package.hbs
@@ -4,7 +4,9 @@
   "description": "{{description}}",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
+  "browser": "./dist/bundle.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": false,
 {{#if supportBundling}}
   "scripts": {
     "build": "tsc && webpack --config webpack.config.js"


### PR DESCRIPTION
- A `browser` package is now declared alongside `main` and `module`
- sideEffects is now false, which improves tree-shaking.