### PR TITLE
Fixed `supportBundling` usage in TS template

### DIFF
--- a/templates/typescript/package.hbs
+++ b/templates/typescript/package.hbs
@@ -4,12 +4,16 @@
   "description": "{{description}}",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
-  "browser": "./dist/bundle.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
 {{#if supportBundling}}
+  "browser": "./dist/bundle.js",
   "scripts": {
     "build": "tsc && webpack --config webpack.config.js"
+  },
+{{else}}
+  "scripts": {
+    "build": "tsc"
   },
 {{/if}}
   "author": {


### PR DESCRIPTION
This comes from @Vinnl comment in #255 

- If `supportBundling is set to false, webpack is not called as part of the `build` script
- The `browser` key is only set if `supportBundling` is true.