### PR TITLE
Added support for "Typescript" programming language

### DIFF
--- a/src/generator/FileGenerator.js
+++ b/src/generator/FileGenerator.js
@@ -5,7 +5,7 @@ const debug = require("debug")("lit-artifact-generator:FileGenerator");
 
 const ARTIFACT_DIRECTORY_ROOT = "./Generated";
 // TODO: Is this redundant with the language-specific ArtifactConfigurator ?
-const SUPPORTED_LANGUAGES = ["Java", "Javascript"];
+const SUPPORTED_LANGUAGES = ["Java", "Javascript", "Typescript"];
 
 class FileGenerator {
   /**


### PR DESCRIPTION
The generator looks up the programming language declared in the configuration file, to fail the generation early if a non-supported programming language is supplied.

This is a quick fix to use the TS artifacts in the React SDK. However, since users can supply their own templates, I suggest that we remove this check altogether in the future.