### PR TITLE
Added a configuration option specifying license name

### DIFF
--- a/src/EndToEnd.test.js
+++ b/src/EndToEnd.test.js
@@ -103,6 +103,7 @@ describe("End-to-end tests", () => {
             inputResources: ["./test/resources/vocabs/schema-snippet.ttl"],
             outputDirectory,
             artifactVersion: "1.0.0",
+            license: { name: "MIT" },
             litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
             moduleNamePrefix: "lit-generated-vocab-",
             noprompt: true
@@ -328,6 +329,7 @@ describe("End-to-end tests", () => {
           ],
           outputDirectory,
           artifactVersion: "1.0.0",
+          license: { name: "MIT" },
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
           moduleNamePrefix: "lit-generated-vocab-",
           noprompt: true
@@ -390,6 +392,7 @@ describe("End-to-end tests", () => {
           outputDirectory,
           artifactVersion: "1.0.0",
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
+          license: { name: "MIT" },
           moduleNamePrefix: "@lit/generated-vocab-",
           noprompt: true
         })
@@ -433,6 +436,7 @@ describe("End-to-end tests", () => {
           termSelectionResource:
             "./test/resources/vocabs/schema-inrupt-ext.ttl",
           artifactVersion: "1.0.0",
+          license: { name: "MIT" },
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
           moduleNamePrefix: "@lit/generated-vocab-",
           noprompt: true
@@ -552,6 +556,7 @@ describe("End-to-end tests", () => {
           termSelectionResource:
             "./test/resources/vocabs/schema-inrupt-ext.ttl",
           artifactVersion: "1.0.5",
+          license: { name: "MIT" },
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
           moduleNamePrefix: "@lit/generated-vocab-",
           noprompt: true
@@ -581,6 +586,7 @@ describe("End-to-end tests", () => {
           outputDirectory,
           artifactVersion: "1.0.5",
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
+          license: { name: "MIT" },
           moduleNamePrefix: "generated-vocab-",
           noprompt: true
         })
@@ -604,6 +610,7 @@ describe("End-to-end tests", () => {
           inputResources: ["./test/resources/vocabs/schema-snippet.ttl"],
           outputDirectory,
           artifactVersion: "1.0.5",
+          license: { name: "MIT" },
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
           moduleNamePrefix: "generated-vocab-",
           noprompt: true
@@ -626,6 +633,7 @@ describe("End-to-end tests", () => {
           inputResources: ["./test/resources/vocabs/schema-inrupt-ext.ttl"],
           outputDirectory,
           artifactVersion: "1.0.5",
+          license: { name: "MIT" },
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
           moduleNamePrefix: "generated-vocab-",
           noprompt: true
@@ -655,6 +663,7 @@ describe("End-to-end tests", () => {
           termSelectionResource:
             "./test/resources/vocabs/schema-inrupt-ext.ttl",
           artifactVersion: "1.0.5",
+          license: { name: "MIT" },
           litVocabTermVersion: LIT_VOCAB_TERM_VERSION,
           moduleNamePrefix: "@lit/generated-vocab-",
           noprompt: true

--- a/src/generator/ArtifactGenerator.js
+++ b/src/generator/ArtifactGenerator.js
@@ -232,7 +232,7 @@ class ArtifactGenerator {
   }
 
   generateLicense() {
-    if (this.artifactData.license) {
+    if (this.artifactData.license && this.artifactData.license.path) {
       this.artifactData.artifactToGenerate.forEach(artifactDetails => {
         const licenseText = fs.readFileSync(this.artifactData.license.path);
         fs.writeFileSync(

--- a/templates/litVocabTermDependent/javascript/package.hbs
+++ b/templates/litVocabTermDependent/javascript/package.hbs
@@ -20,7 +20,9 @@
     {{/each}}
   ],
 {{/if}}
-  "license": "MIT",
+{{#if license}}
+  "license": "{{license/name}}",
+{{/if}}
 {{#if versioning}}
   "repository": {
     "type": "{{versioning.type}}",

--- a/templates/litVocabTermDependent/typescript/package.hbs
+++ b/templates/litVocabTermDependent/typescript/package.hbs
@@ -27,7 +27,9 @@
     {{/each}}
   ],
 {{/if}}
-  "license": "MIT",
+{{#if license}}
+  "license": "{{license/name}}",
+{{/if}}
 {{#if versioning}}
   "repository": {
     "type": "{{versioning.type}}",

--- a/templates/rdfLibraryDependent/javascript/index.hbs
+++ b/templates/rdfLibraryDependent/javascript/index.hbs
@@ -1,3 +1,7 @@
+{{#if license/header}}
+    {{license/header}}
+
+{{/if}}
 {{#each generatedVocabs}}
 module.exports.{{vocabNameUpperCase}} = require('./GeneratedVocab/{{vocabNameUpperCase}}');
 {{/each}}

--- a/templates/rdfLibraryDependent/javascript/rdfext/package.hbs
+++ b/templates/rdfLibraryDependent/javascript/rdfext/package.hbs
@@ -20,7 +20,9 @@
     {{/each}}
   ],
 {{/if}}
-  "license": "MIT",
+{{#if license}}
+  "license": "{{license/name}}",
+{{/if}}
 {{#if versioning}}
   "repository": {
     "type": "{{versioning.type}}",

--- a/templates/rdfLibraryDependent/javascript/rdfext/vocab.hbs
+++ b/templates/rdfLibraryDependent/javascript/rdfext/vocab.hbs
@@ -1,3 +1,7 @@
+{{#if license/header}}
+    {{license/header}}
+
+{{/if}}
 const namespace = require("@rdfjs/namespace");
 
 /**

--- a/templates/rdfLibraryDependent/javascript/rdflib/package.hbs
+++ b/templates/rdfLibraryDependent/javascript/rdflib/package.hbs
@@ -20,7 +20,9 @@
     {{/each}}
   ],
 {{/if}}
-  "license": "MIT",
+{{#if license}}
+  "license": "{{license/name}}",
+{{/if}}
 {{#if versioning}}
   "repository": {
     "type": "{{versioning.type}}",

--- a/templates/rdfLibraryDependent/javascript/rdflib/vocab.hbs
+++ b/templates/rdfLibraryDependent/javascript/rdflib/vocab.hbs
@@ -1,3 +1,7 @@
+{{#if license/header}}
+    {{license/header}}
+
+{{/if}}
 const $rdf = require("rdflib");
 
 /**

--- a/test/resources/yamlConfig/vocab-license.yml
+++ b/test/resources/yamlConfig/vocab-license.yml
@@ -8,6 +8,7 @@ artifactGeneratorVersion: 0.4.2
 license: 
   path: "../licenses/license"
   fileName: "LICENSE"
+  name: "mockPL"
 
 artifactToGenerate:
   - programmingLanguage: TypeScript


### PR DESCRIPTION
Previously, the license was assumed to be MIT. Now, if a license name is provided in the configuration file, it is reproduced in the generated package.json.