### PR TITLE
Enabled adding a prefix to pom.xml artifact id

### DIFF
--- a/templates/litVocabTermDependent/java/rdf4j/pom.hbs
+++ b/templates/litVocabTermDependent/java/rdf4j/pom.hbs
@@ -8,7 +8,7 @@
     <version>{{artifactVersion}}</version>
     <packaging>jar</packaging>
 
-    <name>{{artifactName}}</name>
+    <name>{{artifactPrefix}}{{artifactName}}</name>
     <description>{{description}}</description>
 
     <developers>

--- a/templates/rdfLibraryDependent/java/rdf4j/pom.hbs
+++ b/templates/rdfLibraryDependent/java/rdf4j/pom.hbs
@@ -5,7 +5,7 @@
 
     <groupId>{{groupId}}</groupId>
     <artifactId>{{artifactName}}</artifactId>
-    <version>{{artifactVersion}}</version>
+    <version>{{artifactPrefix}}{{artifactVersion}}</version>
     <packaging>jar</packaging>
 
     <name>{{artifactName}}</name>


### PR DESCRIPTION
An artifact prefix may be specified in the config file, but it was only supported in the `package.json` files. It is now supported by the `pom.xml` files as well, enabling to align naming of Maven artifacts with other company products.