### PR TITLE
0.10.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/lit-artifact-generator",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/lit-artifact-generator",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "A generator for building artifacts (e.g. Java JARs, NPM modules, etc.) from RDF vocabularies.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Critical fix (missing await seems to have caused intermittent faliures when running with globbing for YAMLs).