### PR TITLE
Support added for isDefinedBy and seeAlso.

### DIFF
--- a/src/CommonTerms.js
+++ b/src/CommonTerms.js
@@ -14,6 +14,7 @@ module.exports.RDF = {
 };
 
 const RDFS_NAMESPACE = "http://www.w3.org/2000/01/rdf-schema#";
+module.exports.RDFS_NAMESPACE = RDFS_NAMESPACE;
 module.exports.RDFS = {
   label: rdf.namedNode(`${RDFS_NAMESPACE}label`),
   comment: rdf.namedNode(`${RDFS_NAMESPACE}comment`),
@@ -22,6 +23,8 @@ module.exports.RDFS = {
   Literal: rdf.namedNode(`${RDFS_NAMESPACE}Literal`),
   subClassOf: rdf.namedNode(`${RDFS_NAMESPACE}subClassOf`),
   subPropertyOf: rdf.namedNode(`${RDFS_NAMESPACE}subPropertyOf`),
+  seeAlso: rdf.namedNode(`${RDFS_NAMESPACE}seeAlso`),
+  isDefinedBy: rdf.namedNode(`${RDFS_NAMESPACE}isDefinedBy`),
 };
 
 const DCTERMS_NAMESPACE = "http://purl.org/dc/terms/";
@@ -37,6 +40,7 @@ module.exports.SKOS = {
 };
 
 const OWL_NAMESPACE = "http://www.w3.org/2002/07/owl#";
+module.exports.OWL_NAMESPACE = OWL_NAMESPACE;
 module.exports.OWL = {
   Ontology: rdf.namedNode(`${OWL_NAMESPACE}Ontology`),
   Class: rdf.namedNode(`${OWL_NAMESPACE}Class`),

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -187,6 +187,28 @@ module.exports = class DatasetHandler {
         DatasetHandler.add(definitions, subQuad);
       });
 
+    const seeAlsos = new Set();
+
+    this.subjectsOnlyDataset
+      .match(quad.subject, RDFS.seeAlso, null)
+      .forEach((subQuad) => {
+        seeAlsos.add({ seeAlso: subQuad.object.value });
+      });
+
+    this.fullDataset
+      .match(quad.subject, RDFS.seeAlso, null)
+      .forEach((subQuad) => {
+        seeAlsos.add({ seeAlso: subQuad.object.value });
+      });
+
+    let isDefinedBy = undefined;
+    this.fullDataset
+      .match(quad.subject, RDFS.isDefinedBy, null)
+      .forEach((subQuad) => {
+        // Even if we have multiple values, just keep overwriting.
+        isDefinedBy = subQuad.object.value;
+      });
+
     const comment = DatasetHandler.getTermDescription(
       comments,
       definitions,
@@ -200,6 +222,8 @@ module.exports = class DatasetHandler {
       labels,
       comments,
       definitions,
+      seeAlsos,
+      isDefinedBy,
     };
   }
 
@@ -341,7 +365,7 @@ module.exports = class DatasetHandler {
     });
 
     // We can automatically treat anything marked as a 'sub-class of' as a
-    // class too, regardless of what it's sub-class of!
+    // class too, regardless of what it's a sub-class of!
     this.fullDataset.match(subject, RDFS.subClassOf, null).forEach((quad) => {
       if (this.isNewTerm(quad.subject.value)) {
         result.classes.push(this.handleTerm(quad, result.localNamespace));

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -16,8 +16,8 @@ const RUN_PACKAGING = ["localMaven", "localNpmNode"];
 const ConfigAll = {
   _: "generate",
   force: true,
-  vocabListFile: "../lit-vocab/vocab/**/*.yml",
-  vocabListFileIgnore: "../lit-vocab/lit-artifact-generator/**",
+  vocabListFile: "../lit-vocab/**/*.yml",
+  vocabListFileIgnore: "../lit-vocab/bin/**",
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
   supportBundling: SUPPORT_BUNDLING,
@@ -40,8 +40,7 @@ const ConfigTest = {
 const ConfigLitCommon = {
   _: "generate",
   force: true,
-  vocabListFile:
-    "../lit-vocab/vocab/lit-rdf-vocab/Common/Vocab-List-LIT-Common.yml",
+  vocabListFile: "../lit-vocab/lit-rdf-vocab/Common/Vocab-List-LIT-Common.yml",
   artifactName: "common",
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -52,8 +51,7 @@ const ConfigLitCommon = {
 const ConfigLitCore = {
   _: "generate",
   force: true,
-  vocabListFile:
-    "../lit-vocab/vocab/lit-rdf-vocab/Core/Vocab-List-LIT-Core.yml",
+  vocabListFile: "../lit-vocab/lit-rdf-vocab/Core/Vocab-List-LIT-Core.yml",
   artifactName: "core",
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -65,7 +63,7 @@ const ConfigInruptCommon = {
   _: "generate",
   force: true,
   vocabListFile:
-    "../lit-vocab/vocab/inrupt-rdf-vocab/Common/Vocab-List-Inrupt-Common.yml",
+    "../lit-vocab/inrupt-rdf-vocab/Common/Vocab-List-Inrupt-Common.yml",
   artifactName: "common",
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -77,7 +75,7 @@ const ConfigInruptUiCommon = {
   _: "generate",
   force: true,
   vocabListFile:
-    "../lit-vocab/vocab/inrupt-rdf-vocab/UiComponent/Vocab-List-Inrupt-UiComponent.yml",
+    "../lit-vocab/inrupt-rdf-vocab/UiComponent/Vocab-List-Inrupt-UiComponent.yml",
   artifactName: "ui-common",
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -89,7 +87,7 @@ const ConfigInruptService = {
   _: "generate",
   force: true,
   vocabListFile:
-    "../lit-vocab/vocab/inrupt-rdf-vocab/Service/Vocab-List-Inrupt-Service.yml",
+    "../lit-vocab/inrupt-rdf-vocab/Service/Vocab-List-Inrupt-Service.yml",
   artifactName: "service",
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -101,7 +99,7 @@ const ConfigSolidCommon = {
   _: "generate",
   force: true,
   vocabListFile:
-    "../lit-vocab/vocab/solid-rdf-vocab/Common/Vocab-List-Solid-Common.yml",
+    "../lit-vocab/solid-rdf-vocab/Common/Vocab-List-Solid-Common.yml",
   artifactName: "common",
   npmRegistry: NPM_REGISTRY,
   runNpmInstall: RUN_NPM_INSTALL,
@@ -112,9 +110,7 @@ const ConfigSolidCommon = {
 const ConfigSolidComponent = {
   _: "generate",
   force: true,
-  inputResources: [
-    "../lit-vocab/vocab/solid-rdf-vocab/Component/SolidComponent.ttl",
-  ],
+  inputResources: ["../lit-vocab/solid-rdf-vocab/Component/SolidComponent.ttl"],
   litVocabTermVersion: VERSION_LIT_VOCAB_TERM,
   artifactVersion: "0.1.0",
   moduleNamePrefix: "@solid/generated-vocab-",

--- a/src/generator/VocabGenerator.test.js
+++ b/src/generator/VocabGenerator.test.js
@@ -9,6 +9,7 @@ const {
   RDFS,
   SCHEMA_DOT_ORG,
   OWL,
+  OWL_NAMESPACE,
   VANN,
   DCTERMS,
   SKOS,
@@ -270,6 +271,8 @@ const literalDataset = rdf
     rdf.quad(message, SKOS.definition, rdf.literal("Welcome", "en")),
     rdf.quad(message, SKOS.definition, rdf.literal("Bienvenido", "es")),
     rdf.quad(message, SKOS.definition, rdf.literal("Bienvenue", "fr")),
+    rdf.quad(message, RDFS.seeAlso, rdf.namedNode(OWL_NAMESPACE)),
+    rdf.quad(message, SKOS.isDefinedBy, rdf.namedNode(OWL_NAMESPACE)),
   ]);
 
 describe("Artifact generator unit tests", () => {

--- a/templates/litVocabTermDependent/java/rdf4j/vocab.hbs
+++ b/templates/litVocabTermDependent/java/rdf4j/vocab.hbs
@@ -52,9 +52,13 @@ public class {{vocabNameUpperCase}} implements LitVocab {
     {{#each classes}}
 
     /**
-     *{{#if comment}} {{{comment}}}{{/if}}
+     *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+     *
+     * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
      */
-    public static final LitVocabTerm {{nameEscapedForLanguage}} = new LitVocabTerm(FULL_IRI("{{{name}}}"), true){{#each labels}}{{#if language}}
+    public static final LitVocabTerm {{nameEscapedForLanguage}} = new LitVocabTerm(FULL_IRI("{{{name}}}"), true){{#if isDefinedBy}}
+        .addIsDefinedBy(SimpleValueFactory.getInstance().createIRI("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+        .addSeeAlso(SimpleValueFactory.getInstance().createIRI("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
         .addLabel("{{{valueEscapedForJava}}}", "{{language}}"){{else}}
         .addLabelNoLanguage("{{{valueEscapedForJava}}}"){{/if}}{{/each}}{{#each comments}}{{#if language}}
         .addComment("{{{valueEscapedForJava}}}", "{{language}}"){{else}}
@@ -69,9 +73,13 @@ public class {{vocabNameUpperCase}} implements LitVocab {
     {{#each properties}}
 
     /**
-     *{{#if comment}} {{{comment}}}{{/if}}
+     *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+     *
+     * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
      */
-    public static final LitVocabTerm {{nameEscapedForLanguage}} = new LitVocabTerm(FULL_IRI("{{{name}}}"), true){{#each labels}}{{#if language}}
+    public static final LitVocabTerm {{nameEscapedForLanguage}} = new LitVocabTerm(FULL_IRI("{{{name}}}"), true){{#if isDefinedBy}}
+        .addIsDefinedBy(SimpleValueFactory.getInstance().createIRI("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+        .addSeeAlso(SimpleValueFactory.getInstance().createIRI("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
         .addLabel("{{{valueEscapedForJava}}}", "{{language}}"){{else}}
         .addLabelNoLanguage("{{{valueEscapedForJava}}}"){{/if}}{{/each}}{{#each comments}}{{#if language}}
         .addComment("{{{valueEscapedForJava}}}", "{{language}}"){{else}}
@@ -86,9 +94,13 @@ public class {{vocabNameUpperCase}} implements LitVocab {
     {{#each literals}}
 
     /**
-     *{{#if comment}} {{{comment}}}{{/if}}
+     *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+     *
+     * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
      */
-    public static final LitVocabTerm {{nameEscapedForLanguage}} = new LitVocabTerm(FULL_IRI("{{{name}}}"), true){{#each labels}}{{#if language}}
+    public static final LitVocabTerm {{nameEscapedForLanguage}} = new LitVocabTerm(FULL_IRI("{{{name}}}"), true){{#if isDefinedBy}}
+        .addIsDefinedBy(SimpleValueFactory.getInstance().createIRI("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+        .addSeeAlso(SimpleValueFactory.getInstance().createIRI("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
         .addLabel("{{{valueEscapedForJava}}}", "{{language}}"){{else}}
         .addLabelNoLanguage("{{{valueEscapedForJava}}}"){{/if}}{{/each}}{{#each comments}}{{#if language}}
         .addComment("{{{valueEscapedForJava}}}", "{{language}}"){{else}}

--- a/templates/litVocabTermDependent/javascript/vocab.hbs
+++ b/templates/litVocabTermDependent/javascript/vocab.hbs
@@ -36,14 +36,18 @@ const {{vocabNameUpperCase}} = {
   {{#each classes}}
 
   /**
-   *{{#if comment}} {{{comment}}}{{/if}}
+   *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+   *
+   * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
    */
   {{nameEscapedForLanguage}}: new LitVocabTerm(
     _NS("{{{name}}}"),
     dataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each labels}}{{#if language}}
+  ){{#if isDefinedBy}}
+    .addIsDefinedBy(namedNode("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+    .addSeeAlso(namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
     .addLabelNoLanguage(`{{{valueEscapedForJavaScript}}}`){{/if}}{{/each}}{{#each comments}}{{#if language}}
     .addComment(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -58,14 +62,18 @@ const {{vocabNameUpperCase}} = {
   {{#each properties}}
 
   /**
-   *{{#if comment}} {{{comment}}}{{/if}}
+   *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+   *
+   * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
    */
   {{nameEscapedForLanguage}}: new LitVocabTerm(
     _NS("{{{name}}}"),
     dataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each labels}}{{#if language}}
+  ){{#if isDefinedBy}}
+    .addIsDefinedBy(namedNode("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+    .addSeeAlso(namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
     .addLabelNoLanguage(`{{{valueEscapedForJavaScript}}}`){{/if}}{{/each}}{{#each comments}}{{#if language}}
     .addComment(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -80,7 +88,9 @@ const {{vocabNameUpperCase}} = {
   {{#each literals}}
 
   /**
-   *{{#if comment}} {{{comment}}}{{/if}}
+   *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+   *
+   * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
    */
   {{nameEscapedForLanguage}}: new LitVocabTerm(
     _NS("{{{name}}}"),

--- a/templates/litVocabTermDependent/typescript/vocab.hbs
+++ b/templates/litVocabTermDependent/typescript/vocab.hbs
@@ -37,14 +37,18 @@ const {{vocabNameUpperCase}} = {
   {{#each classes}}
 
   /**
-   *{{#if comment}} {{{comment}}}{{/if}}
+   *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+   *
+   * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
    */
   {{nameEscapedForLanguage}}: new LitVocabTerm(
     _NS("{{{name}}}"),
     dataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each labels}}{{#if language}}
+  ){{#if isDefinedBy}}
+    .addIsDefinedBy(namedNode("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+    .addSeeAlso(namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
     .addLabelNoLanguage(`{{{valueEscapedForJavaScript}}}`){{/if}}{{/each}}{{#each comments}}{{#if language}}
     .addComment(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -59,14 +63,18 @@ const {{vocabNameUpperCase}} = {
   {{#each properties}}
 
   /**
-   *{{#if comment}} {{{comment}}}{{/if}}
+   *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+   *
+   * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
    */
   {{nameEscapedForLanguage}}: new LitVocabTerm(
     _NS("{{{name}}}"),
     dataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each labels}}{{#if language}}
+  ){{#if isDefinedBy}}
+    .addIsDefinedBy(namedNode("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+    .addSeeAlso(namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
     .addLabelNoLanguage(`{{{valueEscapedForJavaScript}}}`){{/if}}{{/each}}{{#each comments}}{{#if language}}
     .addComment(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -81,14 +89,18 @@ const {{vocabNameUpperCase}} = {
   {{#each literals}}
 
   /**
-   *{{#if comment}} {{{comment}}}{{/if}}
+   *{{#if comment}} {{{comment}}}{{/if}}{{#if isDefinedBy}}
+   *
+   * Defined by the vocabulary: {{isDefinedBy}}{{/if}}
    */
   {{nameEscapedForLanguage}}: new LitVocabTerm(
     _NS("{{{name}}}"),
     dataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each labels}}{{#if language}}
+  ){{#if isDefinedBy}}
+    .addIsDefinedBy(namedNode("{{isDefinedBy}}")){{/if}}{{#each seeAlsos}}
+    .addSeeAlso(namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
     .addLabelNoLanguage(`{{{valueEscapedForJavaScript}}}`){{/if}}{{/each}}{{#each comments}}{{#if language}}
     .addComment(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}

--- a/test/resources/vocabs/isDefinedBy.ttl
+++ b/test/resources/vocabs/isDefinedBy.ttl
@@ -1,0 +1,12 @@
+@prefix schema: <http://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+
+schema:Person a rdfs:Class ;
+    rdfs:label "Person" ;
+    rdfs:isDefinedBy owl: ;
+    rdfs:isDefinedBy rdfs: .

--- a/test/resources/vocabs/seeAlso.ttl
+++ b/test/resources/vocabs/seeAlso.ttl
@@ -1,0 +1,13 @@
+@prefix schema: <http://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+
+schema:Person a rdfs:Class ;
+    rdfs:label "Person" ;
+    rdfs:seeAlso schema: ;
+    rdfs:seeAlso rdf: ;
+    rdfs:seeAlso rdfs: .


### PR DESCRIPTION
# New feature description
Support added for rdfs:isDefinedBy and rdfs:seeAlso predicates in vocab templates when they are provided in the source RDF vocab.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).