### PR TITLE
add TypeScript :any type for generated constant objects, move type de…

### DIFF
--- a/templates/generic/typescript/package.hbs
+++ b/templates/generic/typescript/package.hbs
@@ -36,6 +36,7 @@
   },
 {{/if}}
   "dependencies": {
+    "@types/rdf-js": "{{rdfjsTypesVersion}}",
     "@rdfjs/data-model": "{{rdfjsDatamodelVersion}}",
     "@rdfjs/dataset": "{{rdfjsDatasetVersion}}",
     "@rdfjs/namespace": "{{rdfjsNamespaceVersion}}"

--- a/templates/generic/typescript/vocab.hbs
+++ b/templates/generic/typescript/vocab.hbs
@@ -28,7 +28,10 @@ function _NS (localName: string) {
   return (_NAMESPACE + localName);
 }
 
-const {{vocabNameUpperCase}} = {
+// Add 'any' type annotation in case this vocab includes 'NamedNode' instances,
+// for example instances of Constant IRIs (TypeScript compiler will complain of
+// "semantic error TS2742" otherwise).
+const {{vocabNameUpperCase}}:any = {
   PREFIX: "{{vocabPrefix}}",
   NAMESPACE: _NAMESPACE,
   PREFIX_AND_NAMESPACE: { "{{vocabPrefix}}": "{{namespace}}" },

--- a/templates/solidCommonVocabDependent/typescript/package.hbs
+++ b/templates/solidCommonVocabDependent/typescript/package.hbs
@@ -37,13 +37,13 @@
 {{/if}}
   "dependencies": {
     "@inrupt/solid-common-vocab": "{{solidCommonVocabVersion}}",
+    "@types/rdf-js": "{{rdfjsTypesVersion}}",
     "@rdfjs/data-model": "{{rdfjsDatamodelVersion}}",
     "@rdfjs/dataset": "{{rdfjsDatasetVersion}}",
     "@rdfjs/namespace": "{{rdfjsNamespaceVersion}}"
   },
   "devDependencies": {
     "typescript": "{{typescriptVersion}}"{{#if supportBundling}},
-    "@types/rdf-js": "{{rdfjsTypesVersion}}",
     "rollup": "{{rollupVersion}}",
     "rollup-plugin-typescript2": "{{rollupTypescriptPluginVersion}}",
     "@rollup/plugin-commonjs": "{{rollupCommonjsPluginVersion}}",

--- a/templates/solidCommonVocabDependent/typescript/vocab.hbs
+++ b/templates/solidCommonVocabDependent/typescript/vocab.hbs
@@ -24,7 +24,10 @@ function _NS(localName: string): NamedNode {
   return namedNode(`{{namespace}}${localName}`);
 }
 
-const {{vocabNameUpperCase}} = {
+// Add 'any' type annotation in case this vocab includes 'NamedNode' instances,
+// for example instances of Constant IRIs (TypeScript compiler will complain of
+// "semantic error TS2742" otherwise).
+const {{vocabNameUpperCase}}:any = {
   PREFIX: "{{vocabPrefix}}",
   NAMESPACE: "{{namespace}}",
   PREFIX_AND_NAMESPACE: { "{{vocabPrefix}}": "{{namespace}}" },


### PR DESCRIPTION
This PR fixes bug #.
Adds the `:any` type declaration to generated constant objects (to prevent TS compiler error) - probably need a proper fix for this, but after quick discussion with Vinnie and Nic, nothing obvious pops up.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
