### PR TITLE
change default GitHub branch to main

### DIFF
--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -1,11 +1,11 @@
 on:
   pull_request:
     branches:
-    - master
+    - main
 jobs:
   run_npm_test:
     runs-on: ubuntu-latest
-    name: Run tests on all PRs to 'master'
+    name: Run tests on all PRs to 'main'
     steps:
         # Setup
       - name: Checkout repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   of GIST from custom generation test).
 - Tidied up test generation directory names to have all unit tests generated
   under a UNIT_TEST directory.
+- Changed GitHub default branch to 'main'.
 
 ## 0.13.3
 


### PR DESCRIPTION
# New feature description
Changed GitHub default branch from 'master' to 'main'.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).