### PR TITLE
Enforce CI tests for Node 16

### DIFF
--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-20.04]
         node-version: [16.x, 14.x, 12.x]
     runs-on: ${{ matrix.os }}
     name: Run tests on all PRs to 'main'


### PR DESCRIPTION
This actually upgrades our CI to run tests on both Windows and Linux,
and on all three versions of NodeJS that we support.

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).