### PR TITLE
Run status check on push with os matrix

### DIFF
--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -1,4 +1,6 @@
-on: push
+on:
+  pull_request:
+    branches: [main]
 
 env:
   CI: true

--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -1,7 +1,4 @@
-on:
-  pull_request:
-    branches:
-    - main
+on: push
 
 env:
   CI: true
@@ -11,7 +8,7 @@ jobs:
     strategy:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         node-version: [16.x, 14.x, 12.x]
     runs-on: ${{ matrix.os }}
     name: Run tests on all PRs to 'main'


### PR DESCRIPTION
This expands the OS matrix for status check since this is a public repo and the GitHub actions' runs aren't limited anymore.

There might be failing tests in https://github.com/inrupt/artifact-generator/blob/main/src/generator/ArtifactGenerator.test.js.
