### PR TITLE
Fix - add delay before regeneration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-- Fix artifact regeneration tests on MacOS
+- Fix artifact regeneration tests for cases where timestamp based comparison is unreliable
 
 ## 1.0.0 2021-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Fix artifact regeneration tests on MacOS
+
 ## 1.0.0 2021-08-11
 
 - Change default npm registry to local Verdaccio.

--- a/src/generator/ArtifactGenerator.test.js
+++ b/src/generator/ArtifactGenerator.test.js
@@ -326,6 +326,8 @@ describe("Artifact Generator", () => {
       expect(fs.existsSync(generatedFile)).toBe(true);
       const initialGenerationTime = fs.statSync(generatedFile).mtimeMs;
 
+      // Ensure there's at least 1ms before making changes
+      await new Promise((res) => setTimeout(res, 1));
       // Modify our input file.
       Resource.touchFile(testFile);
 
@@ -418,6 +420,8 @@ describe("Artifact Generator", () => {
       const initialGenerationTimeVocab =
         fs.statSync(generatedFileVocab).mtimeMs;
 
+      // Ensure there's at least 1ms before making changes
+      await new Promise((res) => setTimeout(res, 1));
       // Modify our extension file.
       Resource.touchFile(testFileExtension);
 
@@ -508,6 +512,8 @@ describe("Artifact Generator", () => {
       const initialGenerationTimeSecond =
         fs.statSync(generatedFileSecond).mtimeMs;
 
+      // Ensure there's at least 1ms before making changes
+      await new Promise((res) => setTimeout(res, 1));
       // Modify just one of our input files.
       Resource.touchFile(testInputSecond);
 
@@ -522,8 +528,11 @@ describe("Artifact Generator", () => {
         initialGenerationTimeFirst
       );
 
+      // Ensure there's at least 1ms before making changes
+      await new Promise((res) => setTimeout(res, 1));
       // Modify the other input file.
       Resource.touchFile(testInputFirst);
+
       // Record the current time for the non-touched input file.
       const newGenerationTimeSecond = fs.statSync(generatedFileSecond).mtimeMs;
 
@@ -616,6 +625,8 @@ describe("Artifact Generator", () => {
       const initialGenerationTimeSecond =
         fs.statSync(generatedFileSecond).mtimeMs;
 
+      // Ensure there's at least 1ms before making changes
+      await new Promise((res) => setTimeout(res, 1));
       // Modify just our configuration file.
       Resource.touchFile(testConfigFile);
 


### PR DESCRIPTION
This PR fixes failing tests on MacOS, where artifact regeneration tests would intermittently fail if they ran too quickly to see a difference in timestamp after regeneration.

Fixed by adding a 1ms timeout before making changes to trigger regeneration, e.g.
```
// Ensure there's at least 1ms before making changes
await new Promise((res) => setTimeout(res, 1));
// Modify just our configuration file.
Resource.touchFile(testConfigFile);

await artifactGenerator.generate();
```

n.b. normally I'm not a big fan of adding waits/timeouts to tests, but this is a) a very short one b) simpler than switching to a more complex file comparison

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).