### PR TITLE
Include rdfs:Resource as a vocab term property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 - Updated to js-yaml v4 (breaking change of `safeLoad()` to just `load()`).
+- Include 'rdfs:Resource' as a vocab term property (should be rarely, if ever,
+  needed, but no harm in adding).
 
 ## 1.0.1 2021-08-20
 

--- a/src/CommonTerms.js
+++ b/src/CommonTerms.js
@@ -19,6 +19,7 @@ module.exports.RDFS_NAMESPACE = RDFS_NAMESPACE;
 module.exports.RDFS = {
   label: rdf.namedNode(`${RDFS_NAMESPACE}label`),
   comment: rdf.namedNode(`${RDFS_NAMESPACE}comment`),
+  Resource: rdf.namedNode(`${RDFS_NAMESPACE}Resource`),
   Class: rdf.namedNode(`${RDFS_NAMESPACE}Class`),
   Datatype: rdf.namedNode(`${RDFS_NAMESPACE}Datatype`),
   Literal: rdf.namedNode(`${RDFS_NAMESPACE}Literal`),

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -41,6 +41,14 @@ const SUPPORTED_CLASSES = [
 ];
 
 const SUPPORTED_PROPERTIES = [
+  // We find the use of rdfs:Resource in the wild very rare, and would
+  // question it's utility generally, since it's semantics are so extremely
+  // generic.
+  // But since we largely treat the various 'types' of vocabulary terms (i.e.,
+  // Classes, Properties, Constants) the same anyway, in that we look for the
+  // same meta-data and generate much the same output, we treat instances of
+  // 'rdfs:Resource' as if they were just 'rdf:Property'.
+  RDFS.Resource,
   RDF.Property,
   RDF.List,
   RDFS.Datatype,


### PR DESCRIPTION
# New feature description
Include rdfs:Resource as a vocab term property (should be rarely, if ever, needed, but no harm in adding).

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).