### PR TITLE
Added language switch for Widoco, per vocab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Added an optional `widocoLanguages` configuration option for each vocabulary
+  to stipulate that Widoco (if it's configured to run at all) should attempt
+  to generate documentation in multiple languages (which assumes the vocab
+  contains labels in those specified languages, but falls back to English).
+
 ## 1.0.3 2021-09-28
 
 - Updated configuration field names from `artifactPrefix` and `artifactSuffix`

--- a/src/CommandLine.js
+++ b/src/CommandLine.js
@@ -236,16 +236,22 @@ module.exports = class CommandLine {
           `Running Widoco for artifact [${data.artifactName}] using input [${inputResource}], writing to [${destDirectory}]...`
         );
 
-        const command = `java ${log4jPropertyFile} -jar ${widocoJar} -${inputSwitch} ${inputResource} -outFolder ${destDirectory} -rewriteAll -getOntologyMetadata -oops -webVowl -htaccess -licensius`;
+        const languageSwitch = vocab.widocoLanguages
+          ? ` -lang ${vocab.widocoLanguages}`
+          : ``;
+
+        const command = `java ${log4jPropertyFile} -jar ${widocoJar} -${inputSwitch} ${inputResource} -outFolder ${destDirectory} -rewriteAll -getOntologyMetadata -oops -webVowl -htaccess -licensius${languageSwitch}`;
         debug(`Executing comand: [${command}]`);
         ChildProcess.execSync(command);
 
         debug(
-          `Widoco documentation generated for [${
-            data.artifactName
-          }] in directory [${CommandLine.getParentFolder(
+          `Widoco documentation generated for [${inputResource}] in directory [${CommandLine.getParentFolder(
             data.outputDirectory
-          )}/Widoco].`
+          )}/Widoco]${
+            vocab.widocoLanguages
+              ? " in languages [" + vocab.widocoLanguages + "]"
+              : ""
+          }.`
         );
       });
     }

--- a/src/CommandLine.test.js
+++ b/src/CommandLine.test.js
@@ -228,7 +228,7 @@ describe("Command Line unit tests", () => {
         runWidoco: true,
         vocabList: [
           { inputResources: [firstVocab] },
-          { inputResources: [secondVocab] },
+          { inputResources: [secondVocab], widocoLanguages: "en-ga" },
         ],
       });
 

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -196,10 +196,10 @@ describe("Suite for generating common vocabularies (marked as [skip] to prevent 
       // solidCommonVocabVersion: "^4.5.6",
       // widocoLanguages: "en-es",
       // inputResources: [
-      //   "/home/pmcb55/Work/Projects/Customer/Lowes/cust-lowes-homestead-etl-poc/resources/Vocab/ThirdParty/CopyOfVocab/lowes-3rd-party-insidemaps.ttl",
+      //   "/home/pmcb55/Work/Projects/Customer/XXXX/resources/Vocab/ThirdParty/CopyOfVocab/3rd-party-supplier.ttl",
       // ],
       vocabListFile:
-        "/home/pmcb55/Work/Projects/Customer/Lowes/cust-lowes-homestead-etl-poc/resources/Vocab/vocab-lowes-bundle-all.yml",
+        "/home/pmcb55/Work/Projects/Customer/XXXX/resources/Vocab/vocab-bundle-all.yml",
 
       // inputResources: ["http://rdfs.org/resume-rdf/base.rdfs#"],
       // vocabContentTypeHeaderOverride: "application/rdf+xml",

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -192,9 +192,18 @@ describe("Suite for generating common vocabularies (marked as [skip] to prevent 
       // vocabContentTypeHeaderOverride: "application/rdf+xml",
       // nameAndPrefixOverride: "cv",
 
-      inputResources: ["http://rdfs.org/resume-rdf/base.rdfs#"],
-      vocabContentTypeHeaderOverride: "application/rdf+xml",
-      nameAndPrefixOverride: "cv-base",
+      // rdfjsImplVersion: "^1.2.3",
+      // solidCommonVocabVersion: "^4.5.6",
+      // widocoLanguages: "en-es",
+      // inputResources: [
+      //   "/home/pmcb55/Work/Projects/Customer/Lowes/cust-lowes-homestead-etl-poc/resources/Vocab/ThirdParty/CopyOfVocab/lowes-3rd-party-insidemaps.ttl",
+      // ],
+      vocabListFile:
+        "/home/pmcb55/Work/Projects/Customer/Lowes/cust-lowes-homestead-etl-poc/resources/Vocab/vocab-lowes-bundle-all.yml",
+
+      // inputResources: ["http://rdfs.org/resume-rdf/base.rdfs#"],
+      // vocabContentTypeHeaderOverride: "application/rdf+xml",
+      // nameAndPrefixOverride: "cv-base",
 
       // inputResources: ["http://usefulinc.com/ns/doap#"],
       // nameAndPrefixOverride: "doap",
@@ -300,9 +309,9 @@ describe("Suite for generating common vocabularies (marked as [skip] to prevent 
       solidCommonVocabVersion: VERSION_SOLID_COMMON_VOCAB,
       moduleNamePrefix: "@inrupt/generated-custom-vocab-",
       npmRegistry: NPM_REGISTRY,
-      runWidoco: false,
+      runWidoco: true,
       runNpmInstall: RUN_NPM_INSTALL,
-      supportBundling: SUPPORT_BUNDLING,
+      supportBundling: false, //SUPPORT_BUNDLING,
       publish: [DEFAULT_PUBLISH_KEY],
       storeLocalCopyOfVocabDirectory: LOCAL_COPY_OF_VOCAB_DIRECTORY,
     });


### PR DESCRIPTION
# New feature description

Added language switch for Widoco, per vocab (YAML field is `widocoLanguages`). Doesn't seem that the generated artifacts pick up the correct non-English labels and comments (need to look into why).

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).