### PR TITLE
Remove redundant/broken test case

### DIFF
--- a/src/config/GeneratorConfiguration.test.js
+++ b/src/config/GeneratorConfiguration.test.js
@@ -442,22 +442,6 @@ describe("Generator configuration", () => {
     });
   });
 
-  describe("Additional questions.", () => {
-    it("should fail when not providing info and preventing prompt", async () => {
-      inquirer.prompt.mockImplementation(
-        jest.fn().mockReturnValue(Promise.resolve(MOCKED_USER_INPUT))
-      );
-
-      const generatorConfiguration = new GeneratorConfiguration({
-        inputResources: ["test/resources/vocabs/schema-snippet.ttl"],
-        noprompt: true,
-      });
-      expect(
-        generatorConfiguration.completeInitialConfiguration()
-      ).rejects.toThrow("Missing Solid Common Vocab version");
-    });
-  });
-
   describe("License", () => {
     it("should collect the license text from header if provided", () => {
       const generatorConfiguration = GeneratorConfiguration.fromConfigFile(


### PR DESCRIPTION
- Remove test case which is no longer valid (error it tests for stopped being throw as of https://github.com/inrupt/artifact-generator/pull/594)
- Strangely, the case where `expect(received).rejects.toThrow()` instead receives 'promise resolved' does not fail the test assertion. It is however an unhandled promise rejection, which causes an error as of Node 16, which is why we only saw failures on that version.