### PR TITLE
security: rotate npm credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         echo ""
         echo "    npm install @inrupt/artifact-generator"
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}


### PR DESCRIPTION
This migrates us to a new secret managed by the GitHub Organisation for publishing to the inrupt npm organisation.