### PR TITLE
Fix/always set vocabulary iri override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Bug reported by Pete Edwards where 'vocabularyIriOverride' is not being reset
+  once set.
+
 ## 3.0.0 2023-03-05
 
 - Add vocab counts to generated comments.

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -1059,19 +1059,15 @@ module.exports = class DatasetHandler {
     );
   }
 
-  // /**
-  //  * Attempts to find the namespace IRI. Starts by looking for an explicit
-  //  * triple of type 'owl:Ontology', but if none found (e.g., the DCTerms
-  //  * vocab), then it can query for the provided namespace (if any, as it can
-  //  * be NULL too).
-  //  * If we find an RDF Subject, then we call the provided callback function
-  //  * and pass all matching triples for that Subject.
-  //  *
-  //  * @param namespaceIriOverride if not NULL will be used as a fallback Subject if no 'owl:Ontology' triple found
-  //  * @param callback the function to call with matching triples
-  //  * @param defaultResult default value to return if no ontology found
-  //  * @returns {string|*}
-  //  */
+  /**
+   * Attempts to lookup the vocabulary IRI. Starts by looking for an explicit
+   * triple of type 'owl:Ontology', but if none found (e.g., the DCTerms
+   * vocab), then it can query for the provided namespace (if any, as it can
+   * be NULL too).
+   *
+   * @param vocabularyIriOverride if not NULL will be used as a fallback Subject if no 'owl:Ontology' triple found
+   * @returns {string|*}
+   */
   lookupVocabularyIri(vocabularyIriOverride) {
     const allOwlOntologies = this.fullDataset
       .match(null, RDF.type, OWL.Ontology)

--- a/src/generator/ArtifactGenerator.js
+++ b/src/generator/ArtifactGenerator.js
@@ -222,10 +222,8 @@ class ArtifactGenerator {
       this.artifactData.namespaceIriOverride =
         vocabDetails.namespaceIriOverride;
 
-      if (!this.artifactData.vocabularyIriOverride) {
-        this.artifactData.vocabularyIriOverride =
-          vocabDetails.vocabularyIriOverride;
-      }
+      this.artifactData.vocabularyIriOverride =
+        vocabDetails.vocabularyIriOverride;
 
       this.artifactData.ignoreNonVocabTerms = vocabDetails.ignoreNonVocabTerms;
 


### PR DESCRIPTION
This PR fixes a bug reported by Pete Edwards, where the `vocabularyIriOverride` is not reset once set.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
