### PR TITLE
JS and TS templates provide RDF type metadata now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### New features
 
 - Support has been added for Node 18 and Node 20.
+- Updated JS/TS templates to provide RDF type metadata for vocab terms if
+  generating using Solid Common Vocab JS.
 
 ## 3.0.2 2023-04-13 (removed tag 3.0.1)
 

--- a/documentation/advanced-configuration.md
+++ b/documentation/advanced-configuration.md
@@ -208,7 +208,7 @@ artifactToGenerate:
 
   - programmingLanguage: JavaScript
     artifactVersion: 10.11.12
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     artifactDirectoryName: JavaScript
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
     sourceFileExtension: js

--- a/example/demo-DisplayVocabTermMetadata/Vocab/sample-vocab-bundle.yml
+++ b/example/demo-DisplayVocabTermMetadata/Vocab/sample-vocab-bundle.yml
@@ -41,7 +41,7 @@ artifactToGenerate:
     artifactDirectoryName: JavaScript
     sourceFileExtension: js
 
-    solidCommonVocabVersion: "^1.0.0"
+    solidCommonVocabVersion: "^1.4.0"
     rdfjsTypesVersion: "^1.0.1"
     rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs

--- a/example/demo-DisplayVocabTermMetadata/index.js
+++ b/example/demo-DisplayVocabTermMetadata/index.js
@@ -70,3 +70,16 @@ logA(
   `(Well no, Inrupt doesn't yet provide Slovak translations, but we'll seamlessly fallback to English):`
 );
 logA(`  ${SCHEMA_INRUPT.Person.asLanguage("sk").comment}`);
+
+logSpacer();
+logQ(`Is the term 'Person' in Schema.org a Class or Property...?`);
+logA(`  Is it a Class: [${SCHEMA_INRUPT.Person.isRdfClass}]`);
+logA(`  Is it a Property: [${SCHEMA_INRUPT.Person.isRdfProperty}]`);
+SCHEMA_INRUPT.Person.type.forEach((elem) => logA(`  Types: [${elem.value}]`));
+
+
+logSpacer();
+logQ(`Is the term 'shininess' in PetRock a Class or Property...?`);
+logA(`  Is it a Class: [${PET_ROCK.shininess.isRdfClass}]`);
+logA(`  Is it a Property: [${PET_ROCK.shininess.isRdfProperty}]`);
+PET_ROCK.shininess.type.forEach((elem) => logA(`  Types: [${elem.value}]`));

--- a/example/demo-DisplayVocabTermMetadata/package-lock.json
+++ b/example/demo-DisplayVocabTermMetadata/package-lock.json
@@ -46,14 +46,17 @@
       "name": "@inrupt/ag-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
+        "@inrupt/solid-common-vocab": "^1.4.0",
         "@rdfjs/data-model": "^1.1.0"
       }
     },
     "node_modules/@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.4.0.tgz",
+      "integrity": "sha512-iFP1ZoUTpkQU/CEA8yjWda86fXmkENhMQhxrNFOK/LDi2U5s9I7S+K9XyYMs54lm6hLTKGKTeIrSNakQd1lj0w==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0"
+      }
     },
     "node_modules/@rdfjs/data-model": {
       "version": "1.3.4",
@@ -86,9 +89,12 @@
   },
   "dependencies": {
     "@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.4.0.tgz",
+      "integrity": "sha512-iFP1ZoUTpkQU/CEA8yjWda86fXmkENhMQhxrNFOK/LDi2U5s9I7S+K9XyYMs54lm6hLTKGKTeIrSNakQd1lj0w==",
+      "requires": {
+        "@rdfjs/types": "^1.1.0"
+      }
     },
     "@rdfjs/data-model": {
       "version": "1.3.4",
@@ -114,7 +120,7 @@
     "my-generated-vocab-bundle": {
       "version": "file:Generated/SourceCodeArtifacts/JavaScript",
       "requires": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
+        "@inrupt/solid-common-vocab": "^1.4.0",
         "@rdfjs/data-model": "^1.1.0"
       }
     }

--- a/example/vocab/CopyOf-Vocab-List-Common.yml
+++ b/example/vocab/CopyOf-Vocab-List-Common.yml
@@ -62,7 +62,7 @@ artifactToGenerate:
 
     rdfjsTypesVersion: "^1.0.1"
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^0.5.3"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -344,6 +344,12 @@ module.exports = class DatasetHandler {
       "isDefinedBy",
     );
 
+    const rdfTypes = this.getSetOfPredicateObjects(
+      quad.subject,
+      RDF.type,
+      "rdfType",
+    );
+
     const termDescription = DatasetHandler.getTermDescription(
       comments,
       definitions,
@@ -365,6 +371,7 @@ module.exports = class DatasetHandler {
         comments,
         definitions,
       ),
+      rdfTypes,
     };
   }
 

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -157,8 +157,8 @@ const ConfigSolid = {
 };
 
 describe("Suite for generating common vocabularies (marked as [skip] to prevent non-manual execution)", () => {
-  it("Generate ALL vocabs", async () => {
-  // it.skip("Generate ALL vocabs", async () => {
+  // it("Generate ALL vocabs", async () => {
+  it.skip("Generate ALL vocabs", async () => {
     await generateVocabArtifact(ConfigAll);
   }, 6000000);
 
@@ -228,8 +228,8 @@ describe("Suite for generating common vocabularies (marked as [skip] to prevent 
    * or ignoreNonVocabTerms:, or namespaceIriOverride:), so having them recorded
    * here has been really handy sometimes.
    */
-  it("tests a single custom vocab", async () => {
-    // it.skip("tests a single custom vocab", async () => {
+  // it("tests a single custom vocab", async () => {
+  it.skip("tests a single custom vocab", async () => {
     await generateVocabArtifact({
       // inputResources: ["https://w3id.org/plasma#"],
       // inputResources: ["https://w3id.org/oac#"],

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -157,8 +157,8 @@ const ConfigSolid = {
 };
 
 describe("Suite for generating common vocabularies (marked as [skip] to prevent non-manual execution)", () => {
-  // it("Generate ALL vocabs", async () => {
-  it.skip("Generate ALL vocabs", async () => {
+  it("Generate ALL vocabs", async () => {
+  // it.skip("Generate ALL vocabs", async () => {
     await generateVocabArtifact(ConfigAll);
   }, 6000000);
 
@@ -228,11 +228,15 @@ describe("Suite for generating common vocabularies (marked as [skip] to prevent 
    * or ignoreNonVocabTerms:, or namespaceIriOverride:), so having them recorded
    * here has been really handy sometimes.
    */
-  // it("tests a single custom vocab", async () => {
-  it.skip("tests a single custom vocab", async () => {
+  it("tests a single custom vocab", async () => {
+    // it.skip("tests a single custom vocab", async () => {
     await generateVocabArtifact({
-      inputResources: ["https://w3id.org/plasma#"],
-      // inputResources: ["https://raw.githubusercontent.com/coolharsh55/plasma/main/plasma.ttl"],
+      // inputResources: ["https://w3id.org/plasma#"],
+      // inputResources: ["https://w3id.org/oac#"],
+
+      inputResources: [
+        "https://raw.githubusercontent.com/coolharsh55/plasma/main/plasma.ttl",
+      ],
 
       // inputResources: ["http://rdf-vocabulary.ddialliance.org/xkos#"],
 

--- a/src/commandLineProcessor.js
+++ b/src/commandLineProcessor.js
@@ -96,7 +96,7 @@ function processCommandLine(exitOnFail, commandLineArgs) {
               "solidCommonVocabVersion",
               "The version of the Vocab Term to depend on.",
             )
-            .default("solidCommonVocabVersion", "^0.5.3")
+            .default("solidCommonVocabVersion", "^1.4.0")
 
             .alias("in", "runNpmInstall")
             .boolean("runNpmInstall")

--- a/src/config/artifact/NodeArtifactConfigurator.test.js
+++ b/src/config/artifact/NodeArtifactConfigurator.test.js
@@ -9,7 +9,7 @@ const { UNSUPPORTED_CONFIG_PROMPT } = require("../ArtifactConfigurator.test");
 
 const DUMMY_JS_ARTIFACT = {
   artifactVersion: "0.0.1",
-  solidCommonVocabVersion: "^0.1.0",
+  solidCommonVocabVersion: "^1.4.0",
 };
 
 const DUMMY_NPM_MODULE = {

--- a/src/generator/ArtifactGenerator.test.js
+++ b/src/generator/ArtifactGenerator.test.js
@@ -170,7 +170,7 @@ describe("Artifact Generator unit tests", () => {
         inputResources: ["./test/resources/vocab/schema-snippet.ttl"],
         outputDirectory,
         artifactName: "someName",
-        solidCommonVocabVersion: "^1.0.10",
+        solidCommonVocabVersion: "^1.4.0",
         descriptionFallback: "Needs a description...",
         namespaceIriOverride: "https://schema.org/",
       });
@@ -180,7 +180,7 @@ describe("Artifact Generator unit tests", () => {
 
       expect(artifactGenerator.artifactData.artifactName).toEqual("someName");
       expect(artifactGenerator.artifactData.solidCommonVocabVersion).toEqual(
-        "^1.0.10",
+        "^1.4.0",
       );
       expect(artifactGenerator.artifactData.artifactName).not.toEqual(
         MOCKED_ARTIFACT_NAME,

--- a/template/initial-config.hbs
+++ b/template/initial-config.hbs
@@ -37,7 +37,7 @@ artifactToGenerate:
     artifactVersion: 0.1.0
     #    gitRepository: git@github.com:some_user/some_project.git
     npmModuleScope: "@exampleScope/"
-    solidCommonVocabVersion: "^0.5.3"
+    solidCommonVocabVersion: "^1.4.0"
     artifactDirectoryName: JavaScript
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
     sourceFileExtension: js

--- a/template/solidCommonVocabDependent/javascript/vocab.hbs
+++ b/template/solidCommonVocabDependent/javascript/vocab.hbs
@@ -69,7 +69,8 @@ const {{vocabNameUpperCase}} = {
     _DataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -99,7 +100,8 @@ const {{vocabNameUpperCase}} = {
     _DataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -129,7 +131,8 @@ const {{vocabNameUpperCase}} = {
     _DataFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each labels}}{{#if language}}
+  ){{#each rdfTypes}}
+    .addType(_NS("{{rdfType}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
     .addLabelNoLanguage(`{{{valueEscapedForJavaScript}}}`){{/if}}{{/each}}{{#each comments}}{{#if language}}
     .addComment(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}

--- a/template/solidCommonVocabDependent/typescript/rdfjsBase-DataModel/vocab.hbs
+++ b/template/solidCommonVocabDependent/typescript/rdfjsBase-DataModel/vocab.hbs
@@ -69,7 +69,8 @@ const {{vocabNameUpperCase}} = {
     _rdfFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_rdfFactory.namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_rdfFactory.namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_rdfFactory.namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -99,7 +100,8 @@ const {{vocabNameUpperCase}} = {
     _rdfFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_rdfFactory.namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_rdfFactory.namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_rdfFactory.namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -129,7 +131,8 @@ const {{vocabNameUpperCase}} = {
     _rdfFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_rdfFactory.namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_rdfFactory.namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_rdfFactory.namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}

--- a/template/solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
+++ b/template/solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
@@ -71,7 +71,8 @@ const {{vocabNameUpperCase}} = {
     _rdfFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_rdfFactory.namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_rdfFactory.namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_rdfFactory.namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -101,7 +102,8 @@ const {{vocabNameUpperCase}} = {
     _rdfFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_rdfFactory.namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_rdfFactory.namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_rdfFactory.namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}
@@ -131,7 +133,8 @@ const {{vocabNameUpperCase}} = {
     _rdfFactory,
     getLocalStore(),
     {{#if ../strict}}true{{else}}false{{/if}}
-  ){{#each isDefinedBys}}
+  ){{#each rdfTypes}}
+    .addType(_rdfFactory.namedNode("{{rdfType}}")){{/each}}{{#each isDefinedBys}}
     .addIsDefinedBy(_rdfFactory.namedNode("{{isDefinedBy}}")){{/each}}{{#each seeAlsos}}
     .addSeeAlso(_rdfFactory.namedNode("{{seeAlso}}")){{/each}}{{#each labels}}{{#if language}}
     .addLabel(`{{{valueEscapedForJavaScript}}}`, "{{language}}"){{else}}

--- a/test/resources/backwardCompatibility/vocab-list_no-packaging.yml
+++ b/test/resources/backwardCompatibility/vocab-list_no-packaging.yml
@@ -58,7 +58,7 @@ artifactToGenerate:
     npmModuleScope: "@inrupt/"
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^0.1.0"
+    solidCommonVocabVersion: "^1.4.0"
     artifactDirectoryName: JavaScript
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
     sourceFileExtension: js
@@ -74,7 +74,7 @@ artifactToGenerate:
     sourceFileExtension: ook
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^0.1.0"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
 vocabList:

--- a/test/resources/expectedOutput/default-sample-vocab.yml
+++ b/test/resources/expectedOutput/default-sample-vocab.yml
@@ -27,7 +27,7 @@ artifactToGenerate:
     artifactVersion: 0.1.0
     #    gitRepository: git@github.com:some_user/some_project.git
     npmModuleScope: "@exampleScope/"
-    solidCommonVocabVersion: "^0.5.3"
+    solidCommonVocabVersion: "^1.4.0"
     artifactDirectoryName: JavaScript
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
     sourceFileExtension: js

--- a/test/resources/expectedOutput/skipGeneration/vocab-list-no-publish.yml
+++ b/test/resources/expectedOutput/skipGeneration/vocab-list-no-publish.yml
@@ -15,7 +15,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/expectedOutput/skipGeneration/vocab-list-static-with-extension.yml
+++ b/test/resources/expectedOutput/skipGeneration/vocab-list-static-with-extension.yml
@@ -15,7 +15,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/expectedOutput/skipGeneration/vocab-list-static.yml
+++ b/test/resources/expectedOutput/skipGeneration/vocab-list-static.yml
@@ -15,7 +15,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/glob/first/vocab-list-first.yml
+++ b/test/resources/glob/first/vocab-list-first.yml
@@ -13,7 +13,7 @@ artifactToGenerate:
 
     npmModuleScope: "@inrupt/"
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     artifactDirectoryName: JavaScript
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
     sourceFileExtension: js

--- a/test/resources/glob/second/vocab-list-second.yml
+++ b/test/resources/glob/second/vocab-list-second.yml
@@ -16,7 +16,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/packaging/vocab-list-dummy-commands.yml
+++ b/test/resources/packaging/vocab-list-dummy-commands.yml
@@ -52,7 +52,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/packaging/vocab-list-invalid-non-unpublish-command.yml
+++ b/test/resources/packaging/vocab-list-invalid-non-unpublish-command.yml
@@ -16,7 +16,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/packaging/vocab-list-repository.yml
+++ b/test/resources/packaging/vocab-list-repository.yml
@@ -53,7 +53,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/packaging/vocab-list-unpublish-command.yml
+++ b/test/resources/packaging/vocab-list-unpublish-command.yml
@@ -15,7 +15,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/packaging/vocab-list.yml
+++ b/test/resources/packaging/vocab-list.yml
@@ -46,7 +46,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/vocab/vocab-list-including-online.yml
+++ b/test/resources/vocab/vocab-list-including-online.yml
@@ -32,7 +32,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
 vocabList:

--- a/test/resources/vocab/vocab-list-missing-artifact-name.yml
+++ b/test/resources/vocab/vocab-list-missing-artifact-name.yml
@@ -41,7 +41,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/vocab/vocab-list.yml
+++ b/test/resources/vocab/vocab-list.yml
@@ -42,7 +42,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/yamlConfig/empty-vocab-list.yml
+++ b/test/resources/yamlConfig/empty-vocab-list.yml
@@ -32,7 +32,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
 vocabList:

--- a/test/resources/yamlConfig/invalid-vocab-list-no-input-resources.yml
+++ b/test/resources/yamlConfig/invalid-vocab-list-no-input-resources.yml
@@ -32,7 +32,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
 vocabList:

--- a/test/resources/yamlConfig/invalid-vocab-list.yml
+++ b/test/resources/yamlConfig/invalid-vocab-list.yml
@@ -32,7 +32,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
 vocabList:

--- a/test/resources/yamlConfig/namespace-override.yml
+++ b/test/resources/yamlConfig/namespace-override.yml
@@ -40,7 +40,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/yamlConfig/vocab-list-missing-artifactDirectoryName.yml
+++ b/test/resources/yamlConfig/vocab-list-missing-artifactDirectoryName.yml
@@ -39,7 +39,7 @@ artifactToGenerate:
     sourceFileExtension: js
 
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:

--- a/test/resources/yamlConfig/vocab-rdf-library-javascript-rdf-data-factory.yml
+++ b/test/resources/yamlConfig/vocab-rdf-library-javascript-rdf-data-factory.yml
@@ -12,7 +12,7 @@ artifactToGenerate:
     artifactNameSuffix: ""
 
     npmModuleScope: "@inrupt/"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     artifactDirectoryName: JavaScript
 
     babelCoreVersion: "^1.2.3"

--- a/test/resources/yamlConfig/vocab-strict.yml
+++ b/test/resources/yamlConfig/vocab-strict.yml
@@ -20,7 +20,7 @@ artifactToGenerate:
     ##
     strict: true
     rdfjsImplVersion: "^1.1.0"
-    solidCommonVocabVersion: "^1.0.10"
+    solidCommonVocabVersion: "^1.4.0"
     templateInternal: solidCommonVocabDependent/javascript/vocab.hbs
 
     packaging:


### PR DESCRIPTION
# New feature description

If generating artifacts with Solid Common Vocab JS, then the RDF type metadata is now provided via our JavaScript and TypeScript templates.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).