### PR TITLE
Only track major version of GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
      # Makes the current repository available to the workflow.
     - name: Checkout repo
-      uses: actions/checkout@v4.1.0
+      uses: actions/checkout@v4
       # Initializes Node.js for the runner.
     - name: Node setup
-      uses: actions/setup-node@v3.8.1
+      uses: actions/setup-node@v3
       with:
         node-version: "18.x"
         registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
         # Setup
       - name: Checkout repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"


### PR DESCRIPTION
This is the best practice followed as a standard.