### PR TITLE
Pmcb/archive docs

### DIFF
--- a/documentation/ReStructuredText/README.md
+++ b/documentation/ReStructuredText/README.md
@@ -1,0 +1,6 @@
+# Documentation snapshot
+
+This directory contains a snapshot of a number of ReStructuredText
+documentation files related to the Artifact Generator originally from Inrupt's
+online documentation suite, stored here as a form of archive as the official
+documentation evolves.

--- a/documentation/ReStructuredText/generate-vocabulary-artifacts.rst
+++ b/documentation/ReStructuredText/generate-vocabulary-artifacts.rst
@@ -1,0 +1,335 @@
+=============================
+Generate Vocabulary Artifacts
+=============================
+
+In addition to Inrupt's :doc:`vocabulary libraries
+</reference/vocab-rdf>`, which provide convenience objects for many
+common terms/identifiers, Inrupt also provides an `Artifact Generator
+<https://github.com/inrupt/artifact-generator>`_ to generate your own
+set of convenience objects.
+
+The `Artifact Generator`_ can take as input existing online
+vocabulary(ies), local ``.ttl`` file(s), or a combination of both, and
+your generated set can be a subset or an extension of existing
+vocabularies.
+
+Install/Run
+===========
+
+To run, you can use ``npx`` to run the generator without needing to
+install it locally:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator <command> <options>
+
+Alternatively, you can install the generator locally and run:
+
+#. Install locally.
+
+   .. code-block:: sh
+
+      npm install @inrupt/artifact-generator
+
+#. Run by referencing generator's :file:`index.js` from within the
+   ``node_modules`` directory. For example:
+
+   .. code-block:: sh
+
+      node node_modules/@inrupt/artifact-generator/index.js <command> <options>
+
+Commands
+--------
+
+The Artifact Generator supports the following commands
+
+.. list-table::
+   :widths: 20 80
+
+   * - ``generate``
+
+     - Generates the artifacts.
+
+   * - ``init``
+
+     - Initializes a configuration YAML file.
+
+
+   * - ``validate``
+
+     - Validates a configuration YAML file.
+
+   * - ``watch``
+
+     - Watches the input vocabulary resources (specified in the
+       configuration YAML file) to automatically regenerate the
+       artifacts if any of the input resources change.
+
+To see all available commands, you can specify the ``--help`` option:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator --help
+
+Options
+-------
+
+The Artifact Generator includes options to:
+
+- Select a subset of terms to include from the source vocab in the
+  generated artifact.
+
+- Enhance selected terms, for example with additional translations.
+
+- Provide the version number for the output module.
+
+- Specify a custom prefix for the output module name.
+
+- Specify a custom NPM registry where the generated artifact will be
+  published.
+
+- Generate artifacts for other programming languages; e.g., Java.
+
+Options can be provided to the Artifact Generator using the
+Command-Line Interface (CLI) or, for more advanced features
+such as generating artifacts for different programming languages, a
+YAML config file.
+
+To see all available options for the supported commands, specify the
+``--help`` option after the command:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator <command> --help
+
+For example, the following lists the options for the ``generate``
+command:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator generate --help
+
+
+Generate Artifacts using the CLI
+================================
+
+To generate artifacts from existing vocabulary (or vocabularies), use
+the  ``--inputResources`` option to pass in either the URI if the vocabulary is
+online or the filepath if the vocabulary is local.
+
+From a Single Input Resource
+----------------------------
+
+The following example uses the Inrupt's publicly available PetRock
+vocabulary (available at
+https://team.inrupt.net/public/vocab/PetRock.ttl) to generate a
+JavaScript artifact ``PET_ROCK.js``.
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator generate --inputResources https://team.inrupt.net/public/vocab/PetRock.ttl --noprompt
+
+That is, the generate operation specifies the following options:
+
+.. list-table::
+   :widths: 25 75
+
+   * - ``--inputResources``
+
+     - Set to the PetRock vocabulary's URI
+       ``https://team.inrupt.net/public/vocab/PetRock.ttl``.
+
+   * - ``--noprompt``
+
+     - Optional. Specified to suppress interactive prompts during the
+       generation process.
+
+You can run ``npx @inrupt/artifact-generator generate --help`` for more
+details on the options.
+
+The generate operation creates a JavaScript artifact ``PET_ROCK.js``
+that provides constants for all the terms described within the public
+Pet Rock vocabulary. The ``PET_ROCK.js`` artifact is located
+in the ``Generated/SourceCodeArtifacts/JavaScript/GeneratedVocab``
+directory under the current directory.
+
+From Multiple Input Resources
+-----------------------------
+
+The files passed to ``--inputResources`` can be remote or local. You
+can pass in multiple vocabulary resources to ``--inputResources`` as a
+space-delimited list.
+
+.. note::
+
+   If passing in multiple resources, the resources must share the same
+   namespace.
+
+For example, consider the following local files ``Event.ttl`` and
+``Organization.ttl`` that represent subsets of the Schema.org
+vocabulary:
+
+.. code-block:: turtle
+
+   @prefix ns3: <http://www.w3.org/2002/07/owl#> .
+   @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+   @prefix schema: <http://schema.org/> .
+
+   schema:Event a rdfs:Class ;
+      rdfs:label "Event" ;
+      rdfs:comment "An event happening at a certain time and location, such as a concert, lecture, or festival. Ticketing information may be added via the [[offers]] property. Repeated events may be structured as separate Event objects." ;
+      rdfs:subClassOf schema:Thing ;
+      ns3:equivalentClass <http://purl.org/dc/dcmitype/Event> .
+
+   schema:Thing a rdfs:Class ;
+      rdfs:label "Thing" ;
+      rdfs:comment "The most generic type of item." .
+
+.. code-block:: turtle
+
+   @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+   @prefix schema: <http://schema.org/> .
+
+   schema:Organization a rdfs:Class ;
+      rdfs:label "Organization" ;
+      rdfs:comment "An organization such as a school, NGO, corporation, club, etc." ;
+      rdfs:subClassOf schema:Thing .
+
+   schema:Thing a rdfs:Class ;
+      rdfs:label "Thing" ;
+      rdfs:comment "The most generic type of item." .
+
+To generate an artifact using the two resources, pass the file paths to
+``--inputResources`` as a space delimited list.
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator generate --inputResources ./Event.ttl ./Organization.ttl --noprompt
+
+Create a Front-End JavaScript Artifact
+--------------------------------------
+
+By default, the ``generate`` command generates the required `Rollup
+<https://rollupjs.org/>`_ config to bundle the artifact. You can
+deactivate the bundling by setting ``--supportBundling`` to false:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator generate --inputResources https://team.inrupt.net/public/vocab/PetRock.ttl --noprompt --supportBundling=false
+
+Rollup is the default option from the CLI. You can specify other
+bundlers (e.g., Parcel, Webpack, etc.) in the :ref:`YAML configuration
+file <generate-artifacts-using-yaml>`.
+
+Use Generated Artifacts in a JavaScript App
+-------------------------------------------
+
+Once generated, the artifact can be used directly in applications, both
+Node.js and browser based.
+
+For example, after you add ``PET_ROCK.js`` as a dependency to a project as
+``generated-vocab-pet-rock``, you can then use the library as in the
+the following code snippet:
+
+.. literalinclude:: /examples/vocabulary/use-generated-vocab.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE
+   :end-before: END-EXAMPLE
+
+.. _generate-artifacts-using-yaml:
+
+Generate Artifacts using YAML Configuration File
+================================================
+
+The previous examples used the available command-line options to
+configure the artifact generation. Alternatively, you can use a YAML
+configuration file.
+
+For example, the previous ``PET_ROCK.js`` generation can be performed
+using the following YAML config file ``./example/mypetrock.yml``:
+
+.. literalinclude:: /examples/vocabulary/artifact-generator-minimal-config.yml
+   :language: yaml
+   :start-after: BEGIN-EXAMPLE
+   :end-before: END-EXAMPLE
+
+To generate using the configuration file, pass the YAML config file to
+the ``--vocabListFile`` option:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator generate --vocabListFile ./example/mypetrock.yml --noprompt
+
+
+YAML Configuration Options
+--------------------------
+
+You can use the generator to initialise the YAML file with all the
+required options.
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator init
+
+Once generated, you can customize the file as required.
+
+The following example YAML file shows all available configuration options.
+
+.. literalinclude:: /examples/vocabulary/artifact-generator-config.yml
+   :language: yaml
+   :start-after: BEGIN-EXAMPLE
+   :end-before: END-EXAMPLE
+
+Template files
+~~~~~~~~~~~~~~
+
+The template files defined in the YAML determine the code generated
+by the artifact generator. The reason for this configuration is that the
+artifact generator can output vocabulary artifacts in multiple programming
+languages and in a form compatible with any of a number of existing RDF
+libraries. The options that can be specified for ``templateInternal`` can
+be seen in the ``templates`` directory of the artifact generator repo.
+
+If you need to support a programming language or RDF library not
+covered by a provided template, or if you need to make your own changes
+to the generated output, you can supply your own template files using
+``templateCustom``.
+
+For example, the default JavaScript template uses the Inrupt library
+`@inrupt/solid-common-vocab
+<https://www.npmjs.com/package/@inrupt/solid-common-vocab>`_ to output
+generated vocabulary terms as ``VocabTerm`` objects. These objects give
+developers access to all the meta-data associated with individual
+vocabulary terms (e.g., the ``rdfs:comments``, the ``rdfs:seeAlso``
+links, the ``rdfs:isDefinedBy``).
+
+
+YAML Validation
+---------------
+
+Using the ``validate`` command, you can validate a YAML config file to
+ensure it is correctly formatted for artifact generation:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator validate --vocabListFile ./example/your-generator-config.yml
+
+Automatic Artifact Regeneration
+-------------------------------
+
+Using the ``watch`` command, you can start a process to continuously
+watch a list of vocabularies specified in the YAML configuration file
+and re-generate the artifacts in response to changes:
+
+.. code-block:: sh
+
+   npx @inrupt/artifact-generator watch --vocabListFile ./example/your-generator-config.yml
+
+The process runs in the foreground until you hit "Enter".
+
+Repository
+==========
+
+For more examples, as well as example ``.ttl`` files for term
+selection, see the `Artifact generator repository
+<https://github.com/inrupt/artifact-generator>`_.

--- a/documentation/ReStructuredText/use-vocabularies.rst
+++ b/documentation/ReStructuredText/use-vocabularies.rst
@@ -1,0 +1,323 @@
+==========
+Vocabulary
+==========
+
+.. role:: red(strong)
+   :class: text-danger
+
+Vocabularies are collections of identifiers for (generally) related
+terms.
+
+All data is associated with identifiers. That is, when you read data,
+you identify the data you want to read. Similarly, when you write data,
+you identify the data that you are writing.
+
+In the Solid ecosystem, all data identifiers are :term:`IRIs <IRI>`:
+
+#. IRIs are globally unique identifiers. Being globally unique prevents
+   name clashes and allows for different interpretations of common
+   concepts.
+
+   For example, the concept of a ``Person`` is identified in Schema.org
+   with the identifier ``https://schema.org/Person``, and Schema.org's
+   interpretation of the Person concept is described as "A person
+   (alive, dead, undead, or fictional).".
+
+   The `Person Core Ontology <https://www.w3.org/ns/person>`_, however,
+   identifies the Person concept with the identifier
+   ``https://www.w3.org/ns/person#Person``, and their interpretation of
+   the Person concept is described as "An individual person who may be
+   dead or alive, but not imaginary."
+
+   Using IRIs allows for the **unambiguous** differentiation between
+   slightly different interpretations of common concepts, whereas
+   simply using 'Person' as the identifier would lead to confusion when
+   attempting to interoperate.
+
+#. IRIs are dereferenceable, i.e., they can be looked up easily, such as
+   by pasting them into the address bar of any browser.
+
+   Providing meaningful descriptive information at an IRI helps with
+   discovering and understanding the data identified by that IRI.
+
+Pre-existing Vocabularies
+=========================
+
+Many vocabularies (i.e., collections of terms identified with IRIs)
+already exist to identify various concepts (e.g., ``Organization``,
+``Person``) and properties (e.g., ``address`` or ``the starting time of
+an event``). The concepts and properties being identified may be
+general or highly specialized. For a list of some existing
+vocabularies, see :doc:`/tutorial/vocabulary-existing`.
+
+When possible, rather than creating your own vocabulary of
+terms/identifiers, choose from :doc:`existing ones
+</tutorial/vocabulary-existing>`. This helps promote the use of
+shared/common terms, and therefore, :ref:`interoperability
+<vocabulary-interoperability>`.
+
+Using Terms from Vocabularies
+-----------------------------
+
+To define your data entities, you can use terms from any combination of
+vocabularies. That is, to save data for a person, you could use:
+
+- ``http://schema.org/familyName`` as the identifier for the last name
+  and
+
+- ``http://xmlns.com/foaf/0.1/firstName`` as the identifier for the first name.
+
+However, in practice, you are more likely to use the first and last
+name terms from the same vocabulary; e.g.,
+
+- ``http://schema.org/familyName`` and ``http://schema.org/givenName`` or
+
+- ``http://xmlns.com/foaf/0.1/lastName`` and ``http://xmlns.com/foaf/0.1/firstName``.
+
+Nevertheless, as previously mentioned, you can use terms from any
+combination of vocabularies.
+
+For example, the following code snippet uses the ``solid-client``
+function :apisolidclient:`getStringNoLocale
+</modules/thing_get.html#getstringnolocale>` to return specific
+data items (identified by their IRI strings) from a data entity
+``retrievedPerson``.
+
+.. literalinclude:: /examples/vocabulary/use-vocabularies.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE
+   :end-before: END-EXAMPLE
+
+.. _convenience-objects:
+
+Using Convenience Objects
+-------------------------
+
+To simplify the usage of pre-existing vocabularies, Inrupt's vocabulary
+libraries provide convenience objects for many (but not all) common
+terms/identifiers you can use in your data entities:
+
+.. list-table::
+   :widths: 30 70
+
+   * - `vocab-common-rdf <https://www.npmjs.com/package/@inrupt/vocab-common-rdf>`_
+
+     - For some common :abbr:`RDF (Resource Description
+       Framework)`-related vocabularies like `RDFS <http://www.w3.org/2000/01/rdf-schema#>`_,
+       `FOAF <http://xmlns.com/foaf/spec/>`_, `LDP <http://www.w3.org/ns/ldp#>`_
+       or `OWL <http://www.w3.org/2002/07/owl#>`_.
+
+   * - `vocab-solid <https://www.npmjs.com/package/@inrupt/vocab-solid>`_
+
+     - For Solid-related vocabularies like `Solid Terms
+       <https://www.w3.org/ns/solid/terms>`_ and `Workspace
+       <http://www.w3.org/ns/pim/space>`_.
+
+   * - `vocab-inrupt-core <https://www.npmjs.com/package/@inrupt/vocab-inrupt-core>`_
+
+     - For Inrupt specific vocabularies.
+
+Convenience objects contain static constants for common identifiers
+used across Solid. Importing these classes obviates the need for
+developers to hard-code these identifiers in their code. Although you
+can use the IRI strings instead of the convenience objects, these
+objects represent many of the ideas and concepts that are useful in
+Solid itself as well as in Solid applications.
+
+The convenience objects include the (:term:`IRI`) values for each term so you don't
+have to remember them or mistype them. The :apisolidclient:`getStringNoLocale
+</modules/thing_get.html#getstringnolocale>` can accept either (:term:`IRI`)
+strings or the convenience objects. As such, the previous example can
+be rewritten as follows:
+
+.. literalinclude:: /examples/vocabulary/use-vocabularies-bundled.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE
+   :end-before: END-EXAMPLE
+
+- ``FOAF`` provides convenience objects for the `Friend of a Friend
+  Vocabulary <http://xmlns.com/foaf/0.1/>`_. For
+  example, the ``FOAF.firstName`` is a convenience object that includes the
+  ``http://xmlns.com/foaf/0.1/firstName`` IRI.
+
+.. _SCHEMA_INRUPT:
+
+- ``SCHEMA_INRUPT`` is Inrupt's extension of the `schema.org
+  Vocabulary <http://schema.org>`_. It provides convenience objects for
+  a **subset** of terms from the `schema.org Vocabulary`_, adding
+  language tags/translations to labels and comments if missing from
+  schema.org.
+
+  By limiting the number of terms, ``SCHEMA_INRUPT`` aims to make
+  working with select terms from Schema.org easier. Schema.org
+  currently defines over 2,500 terms (see `Organisation of Schema.org
+  <https://schema.org/docs/schemas.html>`_), whereas most applications
+  (including Solid itself) only require specialized subsets of those
+  terms. SCHEMA_INRUPT, which consists of a small set of generally
+  applicable terms, reduces noise, clutter and bundle sizes.
+
+  If you require a Schema.org term not in SCHEMA_INRUPT, you can
+  use the term's IRI string directly in your own code, create your own
+  extension vocabulary, or request that Inrupt add that term to
+  SCHEMA_INRUPT.
+
+- ``VCARD`` provides convenience objects for the `vCard
+  Vocabulary <https://www.w3.org/2006/vcard/ns-2006.html>`_. For
+  example, the ``VCARD.role`` is a convenience object that includes the
+  ``http://www.w3.org/2006/vcard/ns#role`` IRI.
+
+.. _convenience-object-naming-scheme:
+
+.. include:: /includes/topic-vocab-naming-scheme.rst
+
+See also:
+
+- :doc:`/tutorial/read-write-data`.
+
+Generating Custom Convenience Objects
+-------------------------------------
+
+Inrupt also provides an Artifact Generator tool to generate your own
+set of convenience objects. For more information, see
+:doc:`/tutorial/generate-vocabulary-artifacts`.
+
+.. _vocabulary-interoperability:
+
+Interoperability
+================
+
+Consider an example where you are saving your address and a property of
+the address is a zipcode or a postal code. If you save data for this
+property as ``zipcode``, then applications must use ``zipcode`` when
+accessing this data. If others use ``zip``, ``postalCode``, or
+``postcode``, etc. as the identifier when storing their data, then
+applications that use the ``zipcode`` identifier cannot access their
+data.
+
+The use of different identifiers for the same data can hinder
+interoperability. That is, to use an application that retrieves the
+same data from multiple data sources, the application must be updated
+to keep track of the various identifiers in order to access this data.
+Otherwise, the application would not be able to access the data if the
+data source is not using the expected identifier.
+
+Rather than having to keep track of the varying identifiers across data
+sources, the use of the same identifier for the same data can help
+promote interoperability. This idea of coming to broad agreement on
+common identifiers is perhaps epitomized by Schema.org (from Google,
+Microsoft and Yahoo!), and is becoming increasingly common in more
+specialized fields, like biomedicine (e.g. BioPortal
+https://bioportal.bioontology.org/ontologies) and finance (e.g. FIBO
+https://spec.edmcouncil.org/fibo/).
+
+See also:
+
+- `solidproject.org: Well Known Vocabularies <https://solidproject.org/for-developers/apps/vocabularies/well-known>`_
+
+
+.. _vocabulary-data-schemas:
+
+Vocabularies vs. Data Schemas
+=============================
+
+Vocabularies provide terms that can be used to identify data.
+Vocabularies are not data schemas (or in RDF-parlance, `"shapes"
+<https://www.w3.org/2014/data-shapes/charter>`_). That is, unlike data
+schemas (e.g., JSON Schema, relational database schemas (i.e. Data Definition Language (DDL) or XML Schema) which enforce what properties
+must appear and can appear for a data entity, vocabularies impose no
+such restrictions.
+
+Consider an example where you are storing data entities that represent
+people. To describe these data entities, you decide to use the
+``http://schema.org/Person`` identifier from `Schema.org <https://schema.org/>`_ vocabulary.
+That is, the data entity has a property ``RDF.type`` set to
+``http://schema.org/Person``.
+
+Identifying the data entities as being of ``RDF.type``
+``http://schema.org/Person`` imposes no conditions about the data
+properties saved about a person. That is, although
+``http://schema.org/Person`` lists properties/identifiers that are
+categorized/grouped under it, these place no restrictions on how you
+should or could describe a person; i.e.,
+
+- The properties listed under ``http://schema.org/Person`` can be used
+  to identify non-``http://schema.org/Person`` data.
+
+- Your data entity does not need to include all the properties under
+  ``http://schema.org/Person``. In fact, your entity does not need to
+  include any of the properties listed under
+  ``http://schema.org/Person``.  That is, you can identify the Person's properties with
+  :red:`non`-``http://schema.org/Person`` properties, even from other
+  vocabularies. For example, you could decide that you want to define a
+  person as a data entity with the following properties (from `Semantic
+  Arts gist vocabulary <https://www.semanticarts.com/gist/>`_) only:
+
+  - ``https://ontologies.semanticarts.com/gist/name``
+
+  - ``https://ontologies.semanticarts.com/gist/isIdentifiedBy``
+
+- Someone else may also identify their data entities as
+  ``http://schema.org/Person`` but with completely different
+  properties, e.g.:
+
+  - ``https://schema.org/familyName``,
+
+  - ``https://schema.org/givenName``, and
+
+  - ```https://ontologies.semanticarts.com/gist/hasCommunicationAddress``.
+
+Shapes
+======
+
+`Shapes <https://www.w3.org/2014/data-shapes/charter>`_ define what
+properties must and can appear for a data entity; i.e., shapes, not
+vocabularies, constrain the data.
+
+Similar to using a common vocabulary, using shared Shapes for data also
+promotes interoperability. For example, consider multiple applications
+that read and write data entities that represent people.
+
+One application's expected "shape" of a person includes the following
+properties:
+
+- an ``RDF.type`` of ``http://schema.org/Person``
+
+- ``https://schema.org/familyName``,
+
+- ``https://schema.org/givenName``,
+
+- ``https://schema.org/email``, and
+
+- ``https://schema.org/telephone``.
+
+Another application's expected "shape" of a person includes the
+following properties:
+
+- an ``RDF.type`` of ``https://ontologies.semanticarts.com/gist/Person``
+
+- ``https://ontologies.semanticarts.com/gist/name``
+
+- ``https://ontologies.semanticarts.com/gist/isIdentifiedBy``
+
+- ``https://ontologies.semanticarts.com/gist/hasCommunicationAddress``.
+
+The two applications are not interoperable. That is, they cannot act
+upon the other's data. But, if both applications used a common "shape",
+which would also result in the use of the same vocabularies, then
+although developed separately, they would be able to act upon each
+other's data.
+
+For additional information on Shapes, see:
+
+- `Shapes <https://www.w3.org/2014/data-shapes/charter>`_
+
+- `Shapes Constraint Language (SHACL) <https://www.w3.org/TR/shacl/>`_
+
+- `Shape Expressions (ShEx) <http://shexspec.github.io/primer/>`_
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /tutorial/vocabulary-existing
+   /tutorial/generate-vocabulary-artifacts.rst

--- a/documentation/ReStructuredText/vocabulary-existing.rst
+++ b/documentation/ReStructuredText/vocabulary-existing.rst
@@ -1,0 +1,194 @@
+=====================
+Existing Vocabularies
+=====================
+
+Many vocabularies (i.e., collections of terms identified with URLs)
+already exist. For example, the following table lists some existing
+vocabularies that may be helpful in modeling your data:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Vocabulary
+
+     - Notes
+
+   * - `gist (from Semantic Arts) <https://www.semanticarts.com/gist/>`_
+
+     - An upper-ontology (i.e., a generic vocabulary, intended for use
+       across a broad range of applications), related to
+       business/enterprise information (such as organizations, places
+       and addresses, date/time, products and services, etc.). For
+       example:
+
+       - ``gist:Account``
+
+       - ``gist:PostalAddress``
+
+       - ``gist:Transaction``
+
+       - ``gist:startDateTime``
+
+       where ``gist:`` is the recommended prefix for
+       ``https://ontologies.semanticarts.com/gist/``.
+
+   * - `PROV-O <https://www.w3.org/TR/prov-o/>`_
+
+     - *A W3C standard.* For recording general provenance information,
+       such as when an event or an action took place, who executed the
+       action, where the action took place, etc. Such provenance
+       information can form the basis for auditing any event or action,
+       and for tracking the progression of that event of action
+       throughout an entire distributed eco-system. For example:
+
+       - ``prov_o:wasAttributedTo``
+
+       - ``prov_o:actedOnBehalfOf``
+
+       - ``prov_o:wasStartedBy``
+
+       where ``prov_o:`` is the recommended prefix for
+       ``http://www.w3.org/ns/prov#``.
+
+   * - `XML Schema (XSD) <http://www.w3.org/2001/XMLSchema#>`_
+
+     - *A W3C standard.* For all the common programming language data
+       types, such as Integers, Floats, Strings, Dates, etc. For
+       example:
+
+       - ``xsd:dateTime``
+
+       - ``xsd:double``
+
+       where ``xsd:`` is the recommended prefix for
+       ``<http://www.w3.org/2001/XMLSchema#>``.
+
+       The following shows sample triples (in Turtle format) that
+       specify the datatypes of the values:
+
+       .. code-block:: turtle
+          :emphasize-lines: 2
+
+          myPod:someService
+             gist:startDateTime "2002-05-30T09:30:10Z"^^xsd:dateTime.
+
+       .. code-block:: turtle
+          :emphasize-lines: 4
+
+           gist:_day a gist:DurationUnit ;
+              skos:definition "A duration unit that is 24 hours long." ;
+              gist:hasBaseUnit gist:_second ;
+              gist:conversionFactor "8.64e+04"^^xsd:double .
+
+   * - `QUDT for Quantity Kinds, Units of Measure, Dimensions and Data
+       Types <https://www.qudt.org/2.1/catalog/qudt-catalog.html#vocabs>`_
+
+     - For data types more specific than those provided by XML Schema.
+       Comprises a number of related vocabularies, including a "Units"
+       vocabulary for concepts like "kilometers per hour" or "square
+       meter". For example:
+
+       - ``qudt:Unit``
+
+       - ``unit:KiloM-PER-HR``
+
+       - ``unit:M2``
+
+       where:
+
+       - ``qudt:`` is the recommended prefix for
+         ``<http://qudt.org/schema/qudt/>``, and
+
+       - ``unit`` is the recommended prefix for
+         ``<http://qudt.org/2.1/vocab/unit>``.
+
+       The following shows sample triples (in Turtle format) that
+       specify the units (kilometers-per-hour and square meters,
+       respectively) of the values:
+
+       .. code-block:: turtle
+
+          myPod:myCar carVocab:topSpeed "300"^^unit:KiloM-PER-HR .
+
+          myPod:myHouse houseVocab:floorSpace "3000"^^unit:M2 .
+
+   * - `Solid Terms (W3C draft standard) <https://www.w3.org/ns/solid/terms#>`_
+
+     - Defines Solid-specific terms. For example:
+
+       - ``solid:oidcIssuer``
+
+       - ``solid:storgeQuota``
+
+       where ``solid:`` is the recommended prefix for
+       ``<https://www.w3.org/ns/solid/terms#>``.
+
+       The following shows sample triples (in Turtle format) that uses
+       Solid specific terms in the predicates:
+
+       .. code-block:: turtle
+
+          myWebId: solid:oidcIssuer <https://login.inrupt.com> .
+
+       .. code-block:: turtle
+
+          podProvider:newPodConfig solid:storgeQuota "10"^^unit:GigaBYTE .
+
+   * - `Data Privacy Vocabulary (DPV) <https://w3c.github.io/dpv/dpv/>`_
+
+     - Related to the use and processing of personal data based on
+       legislative requirements. For instance, DPV defines a number of
+       hierarchically organized `Purposes <https://w3c.github.io/dpv/dpv/#vocab-purpose>`_
+       that can be used to formally denote the purpose for which a party is
+       requesting access to an individual user's data. For example:
+
+       - ``dpv:GovernmentalOrganisation``
+
+       - ``dpv:Consumer``
+
+       - ``dpv:AcademicResearch``
+
+       where ``dpv:`` is the recommended prefix for ``https://w3id.org/dpv#``.
+
+   * - `Open Digital Rights Language (ODRL) <https://www.w3.org/TR/odrl-vocab/>`_
+
+     - Related to permissions, duties, and prohibitions on the use of
+       content and services. The vocabulary can be used for formally
+       stipulating policies when users are sharing their data. For example:
+
+       - ``odrl:Policy``
+
+       - ``odrl:permissions``
+
+       - ``odrl:consentingParty``
+
+       where ``odrl:`` is the recommended prefix for ``http://www.w3.org/ns/odrl/2/``.
+
+   * - `Simple Knowledge Organization System (SKOS)
+       <https://www.w3.org/2009/08/skos-reference/skos.html>`_
+
+     - Defines hierarchical structures such as thesauri, or taxonomies
+       (such as product catalogs, where, for example, a 'Couch' might
+       come under 'Furniture', that in turn comes under 'Home' in a
+       department store's catalog of products). For example:
+
+       - ``skos:narrower``
+
+       - ``skos:broader``
+
+       - ``skos:definition``
+
+       - ``skos:prefLabel``
+
+       where ``skos:`` is the recommended prefix for ``http://www.w3.org/2004/02/skos/core#``.
+
+Additional Information
+======================
+
+- `Linked Open Vocabularies (LOV)
+  <https://lov.linkeddata.es/dataset/lov/vocabs>`_ to search for other existing
+  vocabularies.
+
+- Oracle's `Knowledge Graph Modeling: Governance & Project Scope
+  <https://www.ateam-oracle.com/post/knowledge-graph-modeling-governance-project-scope>`_.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.7.0",
-        "prettier": "3.1.0"
+        "prettier": "3.2.2"
       },
       "engines": {
         "node": "^14.17.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
@@ -3218,14 +3218,15 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.0",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -5276,9 +5277,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
+      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
-    "prettier": "3.1.0"
+    "prettier": "3.2.2"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -17,7 +17,8 @@ const VERSION_RDFJS_IMPL = "^1.2.3";
 const NPM_REGISTRY = "http://localhost:4873";
 const RUN_NPM_INSTALL = false;
 const SUPPORT_BUNDLING = true;
-const PUBLISH_TO_REPO_LIST = ["mavenLocal", "npmLocal"];
+// const PUBLISH_TO_REPO_LIST = ["mavenLocal", "npmLocal"];
+const PUBLISH_TO_REPO_LIST = ["npmLocal"];
 const LOCAL_COPY_OF_VOCAB_DIRECTORY =
   "./test/Generated/LOCAL_COPY_OF_VOCAB_AS_TURTLE/";
 
@@ -249,7 +250,6 @@ describe("Suite for generating common vocabularies (marked as [skip] to prevent 
       // inputResources: ["https://www.w3.org/TR/dx-prof/rdf/prof.ttl"],
       // nameAndPrefixOverride: "prof",
       // ignoreNonVocabTerms: true,
-
 
       // inputResources: [
       //   "https://protect.oeg.fi.upm.es/odrl-access-control-profile/oac.ttl",


### PR DESCRIPTION
Just archiving documentation being removed/scrubbed from official docs.
Alos removed local Maven publishing for skipped vocab-generation tests (as Inrupt's Java vocab implementation libraries have been removed from Maven Central, and (even local) publication relies on them (so this can be reinstated if those libraries are available in your local `.m2` Maven directory!).