### PR TITLE
allow no packaging, add template used to generated headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
+- Allow YAML files with no packaging info at all, for cases where we just want
+  vocab file generation without packaging up, or publishing.
+- Added the template filename used to the header comments of generate vocab
+  files.
+
 ## 3.1.1 2023-10-02
 
 - Release with correct tag aligned with package.json version number.

--- a/example/demo-CustomTemplate-Elixir/template/stringLiteral/elixir/vocab.hbs
+++ b/example/demo-CustomTemplate-Elixir/template/stringLiteral/elixir/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -22,7 +22,7 @@ const {
 const Resource = require("./Resource");
 const FileGenerator = require("./generator/FileGenerator");
 const BestPracticeReportGenerator = require("./generator/BestPracticeReportGenerator");
-const { describeInput, merge } = require("./Util");
+const { describeInput, describeTemplateVocab } = require("./Util");
 
 const KNOWN_DOMAINS = new Map([
   ["http://xmlns.com/foaf/0.1", "foaf"],
@@ -705,6 +705,7 @@ module.exports = class DatasetHandler {
     result.sourceRdfResources = `Vocabulary built from ${describeInput(
       this.vocabData,
     )}.`;
+    result.sourceTemplateVocab = describeTemplateVocab(this.vocabData);
 
     result.classes = [];
     result.properties = [];

--- a/src/EndToEnd.test.js
+++ b/src/EndToEnd.test.js
@@ -677,7 +677,7 @@ describe("End-to-end tests", () => {
         fs.readFileSync(`${outputDirectoryJavaScript}/package.json`).toString(),
       ).toEqual(
         expect.stringContaining(
-          '"description": "Bundle of [1] vocabularies that includes the following:\\n\\n - schema_inrupt_ext: Inrupt extension to Schema.org terms.',
+          '"description": "Bundle of [1] vocabulary that bundles the following:\\n\\n - schema_inrupt_ext: Inrupt extension to Schema.org terms.',
         ),
       );
     });

--- a/src/Util.js
+++ b/src/Util.js
@@ -43,6 +43,12 @@ function describeInput(artifactInfo) {
       }: [${artifactInfo.inputResources.join(", ")}]`;
 }
 
+function describeTemplateVocab(artifactInfo) {
+  return artifactInfo.artifactToGenerate
+    ? `Source code template file: [${artifactInfo.artifactToGenerate[0].sourceCodeTemplate}].`
+    : `No artifact to generate`;
+}
+
 function mergeDatasets(dataSetArray) {
   let fullData = rdf.dataset();
   dataSetArray.forEach((dataset) => {
@@ -68,5 +74,6 @@ module.exports.getArtifactDirectoryRoot = getArtifactDirectoryRoot;
 module.exports.getArtifactDirectorySourceCode = getArtifactDirectorySourceCode;
 module.exports.normalizePath = normalizeIfFilePath;
 module.exports.describeInput = describeInput;
+module.exports.describeTemplateVocab = describeTemplateVocab;
 module.exports.mergeDatasets = mergeDatasets;
 module.exports.curie = curie;

--- a/src/VocabGeneration.test.js
+++ b/src/VocabGeneration.test.js
@@ -232,9 +232,13 @@ describe("Suite for generating common vocabularies (marked as [skip] to prevent 
   // it("tests a single custom vocab", async () => {
   it.skip("tests a single custom vocab", async () => {
     await generateVocabArtifact({
-      inputResources: ["http://www.w3.org/2006/03/test-description#"],
-      nameAndPrefixOverride: "td",
-      descriptionFallback: "Test description",
+      inputResources: ["https://w3c.github.io/dx-connegp/connegp/altr.ttl"],
+      nameAndPrefixOverride: "altr",
+      ignoreNonVocabTerms: true,
+
+      // inputResources: ["http://www.w3.org/2006/03/test-description#"],
+      // nameAndPrefixOverride: "td",
+      // descriptionFallback: "Test description",
 
       // inputResources: ["https://protect.oeg.fi.upm.es/def/gdprif#"],
       // inputResources: ["https://protect.oeg.fi.upm.es/def/gdprif/ontology.ttl"],

--- a/src/generator/ArtifactGenerator.js
+++ b/src/generator/ArtifactGenerator.js
@@ -337,7 +337,6 @@ class ArtifactGenerator {
 
       this.artifactData.artifactToGenerate.forEach((artifactInfo, index) => {
         if (artifactInfo.packaging) {
-          // TODO: Manage repositories properly.
           this.artifactData.gitRepository = artifactInfo.gitRepository;
           this.artifactData.repository = artifactInfo.repository;
           artifactInfo.packaging.forEach((packagingInfo) => {

--- a/src/generator/ArtifactGenerator.js
+++ b/src/generator/ArtifactGenerator.js
@@ -288,7 +288,7 @@ class ArtifactGenerator {
   }
 
   async collectGeneratedVocabDetails(vocabDatasets) {
-    this.artifactData.description = `Bundle of [${vocabDatasets.length}] vocabularies that includes the following:`;
+    this.artifactData.description = `Bundle of [${vocabDatasets.length}] vocabular${vocabDatasets.length === 1 ? 'y' : 'ies'} that bundles the following:`;
     await Promise.all(
       [...vocabDatasets]
         .sort((vocabDataA, vocabDataB) =>
@@ -336,58 +336,52 @@ class ArtifactGenerator {
       const generatedFullArtifactList = [];
 
       this.artifactData.artifactToGenerate.forEach((artifactInfo, index) => {
-        if (!artifactInfo.packaging) {
-          throw new Error(
-            `No packaging information for artifact number [${index}] from ${describeInput(
-              this.artifactData,
-            )}.`,
-          );
-        }
+        if (artifactInfo.packaging) {
+          // TODO: Manage repositories properly.
+          this.artifactData.gitRepository = artifactInfo.gitRepository;
+          this.artifactData.repository = artifactInfo.repository;
+          artifactInfo.packaging.forEach((packagingInfo) => {
+            debug(
+              `Generating [${artifactInfo.programmingLanguage}] packaging for [${packagingInfo.packagingTool}]`,
+            );
 
-        // TODO: manage repositories properly
-        this.artifactData.gitRepository = artifactInfo.gitRepository;
-        this.artifactData.repository = artifactInfo.repository;
-        artifactInfo.packaging.forEach((packagingInfo) => {
-          debug(
-            `Generating [${artifactInfo.programmingLanguage}] packaging for [${packagingInfo.packagingTool}]`,
-          );
-
-          // As a mere convenience, we generate what we think should be the full
-          // artifact name too - but templates are completely free to create their
-          // own interpretations as they see fit.
-          const suggestedFullArtifactName = ArtifactGenerator.concatIfDefined(
-            ArtifactGenerator.concatIfDefined(
+            // As a mere convenience, we generate what we think should be the full
+            // artifact name too - but templates are completely free to create their
+            // own interpretations as they see fit.
+            const suggestedFullArtifactName = ArtifactGenerator.concatIfDefined(
               ArtifactGenerator.concatIfDefined(
                 ArtifactGenerator.concatIfDefined(
                   ArtifactGenerator.concatIfDefined(
-                    "",
-                    // If we have a Java GroupID, then suffix it with a colon
-                    // (as that's the Java convention).
-                    packagingInfo.groupId === undefined
-                      ? ""
-                      : `${packagingInfo.groupId}:`,
+                    ArtifactGenerator.concatIfDefined(
+                      "",
+                      // If we have a Java GroupID, then suffix it with a colon
+                      // (as that's the Java convention).
+                      packagingInfo.groupId === undefined
+                        ? ""
+                        : `${packagingInfo.groupId}:`,
+                    ),
+                    packagingInfo.npmModuleScope,
                   ),
-                  packagingInfo.npmModuleScope,
+                  artifactInfo.artifactNamePrefix,
                 ),
-                artifactInfo.artifactNamePrefix,
+                this.artifactData.artifactName,
               ),
-              this.artifactData.artifactName,
-            ),
-            artifactInfo.artifactNameSuffix,
-          );
+              artifactInfo.artifactNameSuffix,
+            );
 
-          artifactInfo.suggestedFullArtifactName = suggestedFullArtifactName;
-          generatedFullArtifactList.push({
-            programmingLanguage: artifactInfo.programmingLanguage,
-            suggestedFullArtifactName,
+            artifactInfo.suggestedFullArtifactName = suggestedFullArtifactName;
+            generatedFullArtifactList.push({
+              programmingLanguage: artifactInfo.programmingLanguage,
+              suggestedFullArtifactName,
+            });
+
+            FileGenerator.createPackagingFiles(
+              this.artifactData,
+              artifactInfo,
+              packagingInfo,
+            );
           });
-
-          FileGenerator.createPackagingFiles(
-            this.artifactData,
-            artifactInfo,
-            packagingInfo,
-          );
-        });
+        }
       });
 
       // Generate README in the root. First convert our bundle description into

--- a/src/generator/ArtifactGenerator.js
+++ b/src/generator/ArtifactGenerator.js
@@ -288,7 +288,7 @@ class ArtifactGenerator {
   }
 
   async collectGeneratedVocabDetails(vocabDatasets) {
-    this.artifactData.description = `Bundle of [${vocabDatasets.length}] vocabular${vocabDatasets.length === 1 ? 'y' : 'ies'} that bundles the following:`;
+    this.artifactData.description = `Bundle of [${vocabDatasets.length}] vocabular${vocabDatasets.length === 1 ? "y" : "ies"} that bundles the following:`;
     await Promise.all(
       [...vocabDatasets]
         .sort((vocabDataA, vocabDataB) =>

--- a/src/generator/ArtifactGenerator.test.js
+++ b/src/generator/ArtifactGenerator.test.js
@@ -856,8 +856,8 @@ describe("Artifact Generator unit tests", () => {
     });
   });
 
-  describe("Missing packaging info.", () => {
-    it("should throw with missing packaging info", async () => {
+  describe("Missing packaging info should be fine", () => {
+    it("shouldn't throw if missing packaging info", async () => {
       const outputDirectory =
         "test/Generated/UNIT_TEST/ArtifactGenerator/backwardCompatibility/";
       del.sync([`${outputDirectory}/*`]);
@@ -872,7 +872,12 @@ describe("Artifact Generator unit tests", () => {
       });
 
       const artifactGenerator = new ArtifactGenerator(config);
-      await expect(artifactGenerator.generate()).rejects.toThrowError(yamlFile);
+      await artifactGenerator.generate();
+
+      const outputDirectoryJavaScript = `${outputDirectory}${getArtifactDirectorySourceCode()}/JavaScript/GeneratedVocab`;
+      expect(fs.existsSync(`${outputDirectoryJavaScript}/SCHEMA.js`)).toBe(
+        true,
+      );
     });
   });
 

--- a/template/rdfLibraryDependent/java/commonsRdfServiceLoader/vocab.hbs
+++ b/template/rdfLibraryDependent/java/commonsRdfServiceLoader/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/rdfLibraryDependent/java/commonsRdfSimpleRdf/vocab.hbs
+++ b/template/rdfLibraryDependent/java/commonsRdfSimpleRdf/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/rdfLibraryDependent/java/rdf4j/vocab.hbs
+++ b/template/rdfLibraryDependent/java/rdf4j/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/rdfLibraryDependent/javascript/rdfjsRdfDataFactory/vocab.hbs
+++ b/template/rdfLibraryDependent/javascript/rdfjsRdfDataFactory/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/rdfLibraryDependent/javascript/rdflib/vocab.hbs
+++ b/template/rdfLibraryDependent/javascript/rdflib/vocab.hbs
@@ -10,6 +10,7 @@ const $rdf = require("rdflib");
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
+++ b/template/rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/solidCommonVocabDependent/java/rdf4j/vocab.hbs
+++ b/template/solidCommonVocabDependent/java/rdf4j/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/solidCommonVocabDependent/javascript/vocab.hbs
+++ b/template/solidCommonVocabDependent/javascript/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/solidCommonVocabDependent/typescript/rdfjsBase-DataModel/vocab.hbs
+++ b/template/solidCommonVocabDependent/typescript/rdfjsBase-DataModel/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
+++ b/template/solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/stringLiteral/java/vocab.hbs
+++ b/template/stringLiteral/java/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/stringLiteral/javascript/vocab.hbs
+++ b/template/stringLiteral/javascript/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/template/stringLiteral/typescript/vocab.hbs
+++ b/template/stringLiteral/typescript/vocab.hbs
@@ -8,6 +8,7 @@
  * on '{{generatedTimestamp}}'.
  *
  * {{sourceRdfResources}}
+ * {{sourceTemplateVocab}}
  * The generator detected the following terms in the source vocabulary:
  *  - Classes: [{{classes.length}}]
  *  - Properties: [{{properties.length}}]

--- a/test/resources/expectedOutput/dependency-just-rdf4j/pom.xml
+++ b/test/resources/expectedOutput/dependency-just-rdf4j/pom.xml
@@ -9,7 +9,7 @@
     <packaging>jar</packaging>
 
     <name>generated-vocab-TEST</name>
-    <description>Bundle of [1] vocabularies that includes the following:
+    <description>Bundle of [1] vocabulary that bundles the following:
 
  - schema_inrupt_ext: Inrupt extension to Schema.org terms.</description>
 

--- a/test/resources/expectedOutput/full-ext/package.json
+++ b/test/resources/expectedOutput/full-ext/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/generated-vocab-schema-inrupt-ext",
   "version": "1.0.0",
-  "description": "Bundle of [1] vocabularies that includes the following:\n\n - schema_inrupt_ext: Inrupt extension to Schema.org terms.",
+  "description": "Bundle of [1] vocabulary that bundles the following:\n\n - schema_inrupt_ext: Inrupt extension to Schema.org terms.",
   "sideEffects": false,
   "main": "index.js",
   "module": "wrapper.js",

--- a/test/resources/expectedOutput/java-rdf4j/pom.xml
+++ b/test/resources/expectedOutput/java-rdf4j/pom.xml
@@ -9,7 +9,7 @@
     <packaging>jar</packaging>
 
     <name>generated-vocab-common-TEST</name>
-    <description>Bundle of [2] vocabularies that includes the following:
+    <description>Bundle of [2] vocabularies that bundles the following:
 
  - override-name: Vocabulary for terms used during Source Code Generation from RDF vocabularies.
 

--- a/test/resources/expectedOutput/single/package.json
+++ b/test/resources/expectedOutput/single/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/generated-vocab-schema",
   "version": "1.0.0",
-  "description": "Bundle of [1] vocabularies that includes the following:\n\n - schema: Vocab needs a description.",
+  "description": "Bundle of [1] vocabulary that bundles the following:\n\n - schema: Vocab needs a description.",
   "sideEffects": false,
   "main": "index.js",
   "module": "wrapper.js",


### PR DESCRIPTION
# New feature description
Not really a new feature, but this change allows YAML files with no packaging info at all, for cases where we just want vocab file generation without packaging up, or publishing.
 
# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).